### PR TITLE
Dates on output files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
-default_stages: [commit, push]
+default_stages: [pre-commit, pre-push]
 default_language_version:
-  python: python3.12.4
+  python: python3.13
 repos:
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
@@ -8,7 +8,7 @@ repos:
       - id: isort
         args: ["."]
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 24.10.0
     hooks:
     - id: black
       args: [
@@ -16,7 +16,7 @@ repos:
       ]
       types: ['python']
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
+    rev: 7.1.1
     hooks:
     - id: flake8
       args: [
@@ -41,7 +41,7 @@ repos:
           --convention=google
         ]
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.8
+    rev: 1.7.10
     hooks:
       - id: bandit
         args: [

--- a/export_report_data.py
+++ b/export_report_data.py
@@ -174,7 +174,12 @@ class DataExporter:
                 print(f"Skipping {export_format['export_type']} for {export_format['output_filename']}")
                 continue
 
-            print(f"Exporting {export_format['export_type']} to {export_format['output_filename']}")
+            print(f"Exporting {export_format['export_type']} to {self.config['output_report_name']}")
+
+            # Perform string subs for output filename (include output_report_name in all files)
+            export_format["output_filename"] = export_format["output_filename"].replace(
+                "[output_report_name]", self.config["output_report_name"]
+            )
 
             # Check if export_format["input_filename"] exists
             if "input_filename" in export_format:

--- a/export_report_data_config.json
+++ b/export_report_data_config.json
@@ -1,69 +1,69 @@
 {
-    "input_results_folder_name": "source_folder",
-    "output_report_name": "09-2024",
+    "input_results_folder_name": "results_folder_name_here",
+    "output_report_name": "2024-09",
     "export_formats": [
         {
             "enabled": true,
             "export_type": "generate_axe_core_template_aware_file",
             "input_filename": "axe_core_audit.csv",
-            "output_filename": "axe_core_audit_template_aware.csv"
+            "output_filename": "[output_report_name]_axe_core_audit_template_aware.csv"
         },
         {
             "enabled": true,
             "export_type": "axe_core_template_aware_leaderboard",
             "input_filename": "axe_core_audit.csv",
-            "output_filename": "axe_core_audit_leaderboard.csv"
+            "output_filename": "[output_report_name]_axe_core_audit_leaderboard.csv"
         },
         {
             "enabled": true,
             "export_type": "leaderboard",
             "input_filename": "focus_indicator_audit.csv",
-            "output_filename": "focus_indicator_audit_leaderboard.csv",
+            "output_filename": "[output_report_name]_focus_indicator_audit_leaderboard.csv",
             "query": "SELECT organisation, base_url, SUM(count) as count FROM cwac_table GROUP BY base_url ORDER BY count DESC"
         },
         {
             "enabled": true,
             "export_type": "leaderboard",
             "input_filename": "reflow_audit.csv",
-            "output_filename": "reflow_audit_leaderboard.csv",
+            "output_filename": "[output_report_name]_reflow_audit_leaderboard.csv",
             "query": "SELECT organisation, base_url, AVG(overflow_amount_px) AS overflow_amount_px FROM cwac_table GROUP BY base_url ORDER BY overflow_amount_px DESC;"
         },
         {
             "enabled": true,
             "export_type": "leaderboard",
             "input_filename": "language_audit.csv",
-            "output_filename": "language_audit_leaderboard.csv",
+            "output_filename": "[output_report_name]_language_audit_leaderboard.csv",
             "query": "SELECT organisation, base_url, AVG(smog_gl) AS smog_grade_level FROM cwac_table GROUP BY base_url ORDER BY smog_grade_level DESC"
         },
         {
             "enabled": true,
             "export_type": "raw_data",
             "input_filename": "axe_core_audit.csv",
-            "output_filename": "axe_core_audit.csv"
+            "output_filename": "[output_report_name]_axe_core_audit.csv"
         },
         {
             "enabled": true,
             "export_type": "raw_data",
             "input_filename": "axe_core_audit_template_aware.csv",
-            "output_filename": "axe_core_audit_template_aware.csv"
+            "output_filename": "[output_report_name]_axe_core_audit_template_aware.csv"
         },
         {
             "enabled": true,
             "export_type": "raw_data",
             "input_filename": "focus_indicator_audit.csv",
-            "output_filename": "focus_indicator_audit.csv"
+            "output_filename": "[output_report_name]_focus_indicator_audit.csv"
         },
         {
             "enabled": true,
             "export_type": "raw_data",
             "input_filename": "reflow_audit.csv",
-            "output_filename": "reflow_auditt.csv"
+            "output_filename": "[output_report_name]_reflow_auditt.csv"
         },
         {
             "enabled": true,
             "export_type": "raw_data",
             "input_filename": "language_audit.csv",
-            "output_filename": "language_audit.csv"
+            "output_filename": "[output_report_name]_language_audit.csv"
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "postinstall": "npx @puppeteer/browsers install chrome@122.0.6261.39"
   },
   "dependencies": {
-    "axe-core": "^4.10.0",
+    "axe-core": "^4.10.2",
     "@mozilla/readability": "^0.5.0"
   }
 }

--- a/src/audit_plugins/element_audit.py
+++ b/src/audit_plugins/element_audit.py
@@ -6,18 +6,19 @@ can be customised in the config file using a CSS selector.
 """
 
 import logging
-import selenium.common.exceptions as sel_exceptions
+from typing import Any, Union
 
-from typing import Any, Union, List
+from bs4 import BeautifulSoup
 
 from config import config
-from src.audit_manager import AuditManager
 from src.audit_plugins.default_audit import DefaultAudit
 from src.browser import Browser
-from bs4 import BeautifulSoup
+
 
 class ElementAudit:
     """element audit."""
+
+    # pylint: disable=too-many-instance-attributes
 
     audit_type = "ElementAudit"
 
@@ -39,21 +40,20 @@ class ElementAudit:
             list[Any]: rows of test data
             bool: False if test fails, else a list of results
         """
-
         # Scrape the page source of the loaded browser
         try:
             page_source = self.browser.get_page_source()
         except Exception as exc:
-            logging.error(f"Error getting page source: {exc}")
+            logging.error("Error getting page source: %s", exc)
             return False
 
         # Try to parse using BeautifulSoup
         try:
             soup = BeautifulSoup(page_source, "lxml")
         except Exception as exc:
-            logging.error(f"Error parsing page source: {exc}")
+            logging.error("Error parsing page source: %s", exc)
             return False
-        
+
         # Find all elements of the target type (css selector)
         elements = soup.select(self.target_element)
 
@@ -62,9 +62,7 @@ class ElementAudit:
         # For each element found, create a row of data
         for element in elements:
             # get element outer html
-            element_data = {
-                "element_html": element.prettify()
-            }
+            element_data = {"element_html": element.prettify()}
             found_elements.append(element_data)
 
         # Get page information from DefaultAudit

--- a/src/audit_plugins/reflow_audit.py
+++ b/src/audit_plugins/reflow_audit.py
@@ -98,7 +98,8 @@ class ReflowAudit:
 
         # Run a ScreenshotAudit if the page overflows
         if config.audit_plugins["reflow_audit"]["screenshot_failures"] and overflow_amount > 0:
-            from src.audit_plugins.screenshot_audit import ScreenshotAudit  # pylint: disable=import-outside-toplevel
+            from src.audit_plugins.screenshot_audit import \
+                ScreenshotAudit  # pylint: disable=import-outside-toplevel
 
             screenshot_audit = ScreenshotAudit(
                 browser=self.browser,


### PR DESCRIPTION
Files generated with `export_report_data.py` now prepend all filenames with the value of `"output_report_name"` (specified in  `export_report_data_config.json`). This can be used to add YYYY-MM to the start of reports.

Example usage:
1. Run CWAC scan
2. Configure `export_report_data_config.json` to ingest the new data in `./results/`
3. In `export_report_data_config.json`, set the value of `output_report_name` to the YYYY-MM date of the scan i.e. 2024-11
4. All files `export_report_data.py` generates will have the `output_report_name` prepended.
5. Note: I recommend _prepending_ YYYY-MM dates to the files, as this enables you to easily sort output files by date - putting the date at the end of the filename makes it way harder to chronologically sort data. 

Other changes:
1. Updated pip dependencies in requirements.txt to latest versions
2. Tidied up `element_audit.py` which had several unused imports, incorrect logging formats etc.
3. Updated to latest axe-core version