### PR TITLE
fix text/plain check for robots.txt

### DIFF
--- a/src/crawler.py
+++ b/src/crawler.py
@@ -387,7 +387,7 @@ class Crawler:
             response = requests.get(robots_txt_url, headers={"User-Agent": config.user_agent}, timeout=10)
             # Check Content-Type is text/plain (in a safe way)
             is_content_type_set = "Content-Type" in response.headers
-            if is_content_type_set and response.headers["Content-Type"] != "text/plain":
+            if is_content_type_set and "text/plain" not in response.headers["Content-Type"]:
                 raise ValueError(
                     f"robots.txt has invalid Content-Type {robots_txt_url} {response.headers['Content-Type']}"
                 )

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -385,13 +385,11 @@ class Crawler:
         try:
             logging.info("Fetching robots.txt %s", robots_txt_url)
             response = requests.get(robots_txt_url, headers={"User-Agent": config.user_agent}, timeout=10)
-            # Check Content-Type is text/plain (in a safe way)
-            is_content_type_set = "Content-Type" in response.headers
-            if is_content_type_set and "text/plain" not in response.headers["Content-Type"]:
-                raise ValueError(
-                    f"robots.txt has invalid Content-Type {robots_txt_url} {response.headers['Content-Type']}"
-                )
             response.raise_for_status()
+            if "Content-Type" in response.headers and "text/plain" not in response.headers.get("Content-Type", "").lower():
+                raise ValueError(
+                    f"{robots_txt_url} has invalid Content-Type {response.headers['Content-Type']}"
+                )
         except requests.exceptions.RequestException as exc:
             logging.error("Failed to fetch robots.txt %s", robots_txt_url)
             raise exc


### PR DESCRIPTION
Currently crawler.py checks that Content-Type header for the website's robots.txt file doesn't equal (!=) "text/plain", but Content-Type typically is "text/plain; charset=utf-8", which will never match, causing crawler.py to raise a ValueError. This fix checks that the Content-Type doesn't include "text/plain" and only then throws the error.