### PR TITLE
ci: have `black` actually check files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: psf/black@stable
         with:
           version: 24.8.0
-          options: '--line-length=120'
+          options: '--line-length=120 --check --diff'
   install:
     permissions:
       contents: read # to fetch (actions/checkout)


### PR DESCRIPTION
Turns out that providing `options` to the action overrides the default value which is what has `black` fail CI if there are files that need formatting 😅 