### PR TITLE
chore: add types for `requests` and `pandas`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 beautifulsoup4==4.12.3
 types-beautifulsoup4==4.12.0.20240907
 requests==2.32.3
+types-requests==2.32.4.20250611
 selenium==4.25.0
 lxml==5.3.0
 responses==0.25.2
@@ -15,5 +16,6 @@ pydocstyle==6.3.0
 opencv-python==4.10.0.82
 numpy==1.26.4
 pandas==2.2.2
+pandas-stubs==2.2.2.240909
 pyarrow==16.1.0
 nltk==3.9.1


### PR DESCRIPTION
These allow `mypy` to understand the related external libraries - I've tried to use the same version as the runtime packages where possible