### PR TITLE
refactor: make sure `isort` and `black` are happy with each other

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     rev: 5.13.2
     hooks:
       - id: isort
-        args: ["."]
+        args: ["--profile black", "."]
   - repo: https://github.com/psf/black
     rev: 24.10.0
     hooks:

--- a/src/audit_plugins/reflow_audit.py
+++ b/src/audit_plugins/reflow_audit.py
@@ -98,7 +98,9 @@ class ReflowAudit:
 
         # Run a ScreenshotAudit if the page overflows
         if config.audit_plugins["reflow_audit"]["screenshot_failures"] and overflow_amount > 0:
-            from src.audit_plugins.screenshot_audit import ScreenshotAudit  # pylint: disable=import-outside-toplevel
+            from src.audit_plugins.screenshot_audit import (
+                ScreenshotAudit,  # pylint: disable=import-outside-toplevel
+            )
 
             screenshot_audit = ScreenshotAudit(
                 browser=self.browser,


### PR DESCRIPTION
Turns out the defaults of these tools disagree slightly, so we need to explicitly tell `isort` that we'd like it to play nice with `black`