### PR TITLE
chore: add return type definition to function

### DIFF
--- a/export_report_data.py
+++ b/export_report_data.py
@@ -62,7 +62,7 @@ class DataExporter:
 
         return url_count_df
 
-    def generate_axe_core_leaderboard(self):
+    def generate_axe_core_leaderboard(self) -> pd.DataFrame:
         """Generates the axe-core leaderboard dataframe."""
         # Generate the SQL query for the axe-core template aware report
         query = self.generate_axe_core_template_aware_query()


### PR DESCRIPTION
This addresses an error being raised by `mypy`