### PR TITLE
chore: add missing type parameters to generic `dict`

### DIFF
--- a/export_report_data.py
+++ b/export_report_data.py
@@ -9,6 +9,7 @@ import json
 import os
 import sqlite3
 from datetime import date
+from typing import Any
 
 import pandas as pd
 
@@ -229,7 +230,7 @@ class DataExporter:
         audit_df = pd.read_csv(self.input_path + input_filename)
         return audit_df
 
-    def import_config_file(self) -> dict:
+    def import_config_file(self) -> dict[str, Any]:
         """Import export_report_data_config.json."""
         with open("export_report_data_config.json", "r", encoding="utf-8") as file:
             config = json.load(file)


### PR DESCRIPTION
This is required when running `mypy` in strict mode - I've used `Any` for now as while it is technically possible to represent the shape of the JSON file, it'd be a lot more work and I'm trying to get to the point that we can run `mypy` in CI first