### PR TITLE
chore: address `no-any-return` violations with `cast`

### DIFF
--- a/export_report_data.py
+++ b/export_report_data.py
@@ -9,7 +9,7 @@ import json
 import os
 import sqlite3
 from datetime import date
-from typing import Any
+from typing import Any, cast
 
 import pandas as pd
 
@@ -239,7 +239,7 @@ class DataExporter:
     def import_config_file(self) -> dict[str, Any]:
         """Import export_report_data_config.json."""
         with open("export_report_data_config.json", "r", encoding="utf-8") as file:
-            config = json.load(file)
+            config = cast(dict[str, Any], json.load(file))
         return config
 
     def template_aware_algorithm(self, input_df: pd.DataFrame, groupby_cols: list[str]) -> pd.DataFrame:

--- a/src/browser.py
+++ b/src/browser.py
@@ -7,7 +7,7 @@ import logging
 import platform
 import time
 import traceback
-from typing import Any, Union
+from typing import Any, Union, cast
 
 import selenium
 from selenium import webdriver
@@ -154,7 +154,7 @@ class Browser:
             str: base URI of current page.
         """
         try:
-            return self.driver.execute_script("return document.baseURI")
+            return cast(str, self.driver.execute_script("return document.baseURI"))
         except Exception as exc:
             logging.exception("TimeoutException when getting base URI")
             self.safe_restart()

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -11,7 +11,7 @@ import time
 import urllib
 import urllib.robotparser
 from queue import SimpleQueue
-from typing import Any
+from typing import Any, cast
 
 import requests
 import selenium.common.exceptions
@@ -427,7 +427,7 @@ class Crawler:
 
         # If the domain is in config.robots_txt_cache, use that
         if domain in config.robots_txt_cache:
-            robot_parser = config.robots_txt_cache[domain]
+            robot_parser = cast(urllib.robotparser.RobotFileParser, config.robots_txt_cache[domain])
             logging.info("Using cached robots.txt for %s", domain)
             result = robot_parser.can_fetch(config.user_agent_product_token, url)
             logging.info("robots.txt result for %s was %s", url, "allow" if result else "disallow")


### PR DESCRIPTION
This addresses all our `no-any-return` violations which happen because:
* `export_report_data.py`: `json.load` reads an arbitrary external file so cannot return anything other than `Any` that we need to explicitly `cast` into a more concrete shape
* `src/browser.py`: it seems that the `execute_script` function does not have an explicit return type
* `src/crawler`: we're using `__getattr__` in our `Config` class to passthrough most properties to an internal `dict`, meaning there's no way to strongly type the keys (ideally we should not do this in the long-run)