### PR TITLE
fix: include BOM in CSV files

### DIFF
--- a/config.py
+++ b/config.py
@@ -83,7 +83,7 @@ class Config:
         )
 
         # Write self.config to the results folder for reference
-        with open(f"{folder_path}/config.json", "w", encoding="utf-8") as file:
+        with open(f"{folder_path}/config.json", "w", encoding="utf-8-sig") as file:
             json.dump(self.config, file, indent=4)
 
         # Ensure base_url_crawl_path is within base_urls folder
@@ -165,7 +165,7 @@ class Config:
                 raise ValueError("config_filename must be alphanumeric, underscores, and hyphens")
         else:
             config_filename = "config_default.json"
-        with open("./config/" + config_filename, "r", encoding="utf-8") as file:
+        with open("./config/" + config_filename, "r", encoding="utf-8-sig") as file:
             # Write the config file to the results folder
             return json.load(file)
 
@@ -209,7 +209,7 @@ class Config:
             if filename.endswith(".csv"):
                 with open(
                     os.path.join(self.config["base_urls_crawl_path"], filename),
-                    encoding="utf-8",
+                    encoding="utf-8-sig",
                     newline="",
                 ) as file:
                     reader = csv.reader(file)

--- a/cwac.py
+++ b/cwac.py
@@ -141,7 +141,7 @@ class CWAC:
             if filename.endswith(".csv"):
                 with open(
                     os.path.join(folder_path, filename),
-                    encoding="utf-8",
+                    encoding="utf-8-sig",
                     newline="",
                 ) as file:
                     reader = csv.reader(file)

--- a/export_report_data.py
+++ b/export_report_data.py
@@ -165,8 +165,8 @@ class DataExporter:
             output_filename (str): The output filename.
         """
         with (
-            open(self.input_path + input_filename, "r", encoding="utf-8") as input_file,
-            open(self.output_path + output_filename, "w", encoding="utf-8") as output_file,
+            open(self.input_path + input_filename, "r", encoding="utf-8-sig") as input_file,
+            open(self.output_path + output_filename, "w", encoding="utf-8-sig") as output_file,
         ):
             output_file.write(input_file.read())
 
@@ -238,7 +238,7 @@ class DataExporter:
 
     def import_config_file(self) -> dict[str, Any]:
         """Import export_report_data_config.json."""
-        with open("export_report_data_config.json", "r", encoding="utf-8") as file:
+        with open("export_report_data_config.json", "r", encoding="utf-8-sig") as file:
             config = cast(dict[str, Any], json.load(file))
         return config
 

--- a/src/audit_plugins/axe_core_audit.py
+++ b/src/audit_plugins/axe_core_audit.py
@@ -54,7 +54,7 @@ class AxeCoreAudit:
         """Load axe.min.js into a string."""
         if not AuditManager.axe_core_js:
             try:
-                with open("./node_modules/axe-core/axe.min.js", encoding="utf-8") as file:
+                with open("./node_modules/axe-core/axe.min.js", encoding="utf-8-sig") as file:
                     logging.info("Reading axe.min.js")
                     axe_min_js = file.read()
             except FileNotFoundError:

--- a/src/audit_plugins/language_audit.py
+++ b/src/audit_plugins/language_audit.py
@@ -168,11 +168,11 @@ class LanguageAudit:
         """
         # Read Readability.js
         path_1 = "./node_modules/@mozilla/readability/Readability.js"
-        with open(path_1, "r", encoding="utf-8") as file:
+        with open(path_1, "r", encoding="utf-8-sig") as file:
             readability_js = file.read()
 
         path_2 = "./node_modules/@mozilla/readability/Readability-readerable.js"
-        with open(path_2, "r", encoding="utf-8") as file:
+        with open(path_2, "r", encoding="utf-8-sig") as file:
             readability_js += file.read()
 
         # JavaScript to execute Readability

--- a/src/audit_plugins/screenshot_audit.py
+++ b/src/audit_plugins/screenshot_audit.py
@@ -67,7 +67,7 @@ class ScreenshotAudit:
         #     + self.audit_id
         #     + ".html",
         #     "w",
-        #     encoding="utf-8",
+        #     encoding="utf-8-sig",
         # ) as file:
         #     file.write(source)
 

--- a/src/output.py
+++ b/src/output.py
@@ -48,7 +48,7 @@ class CSVWriter:
         Returns:
             list[dict[Any, Any]]: list of dictionaries
         """
-        with self.get_file_lock(path), open(path, "r", encoding="utf-8") as csvfile:
+        with self.get_file_lock(path), open(path, "r", encoding="utf-8-sig") as csvfile:
             reader = csv.DictReader(csvfile)
             rows = list(reader)
         return rows
@@ -88,7 +88,7 @@ class CSVWriter:
         with self.get_file_lock(path):
             file_exists = False if overwrite else os.path.exists(path)
             file_mode = "w" if overwrite else "a"
-            with open(path, file_mode, encoding="utf-8") as csvfile:
+            with open(path, file_mode, encoding="utf-8-sig") as csvfile:
                 writer = csv.DictWriter(csvfile, fieldnames=keys)
                 if not file_exists:
                     writer.writeheader()


### PR DESCRIPTION
This helps ensure applications correctly interpret the CSV files as UTF-8 - notably right now Excel will not, resulting in some characters being mangled