### PR TITLE
fix: account for optional data being included in `content-type` header

### DIFF
--- a/src/crawler.py
+++ b/src/crawler.py
@@ -7,6 +7,7 @@ import importlib
 import logging
 import posixpath
 import random
+import re
 import time
 import urllib
 import urllib.robotparser
@@ -387,7 +388,9 @@ class Crawler:
             response = requests.get(robots_txt_url, headers={"User-Agent": config.user_agent}, timeout=10)
             # Check Content-Type is text/plain (in a safe way)
             is_content_type_set = "Content-Type" in response.headers
-            if is_content_type_set and response.headers["Content-Type"] != "text/plain":
+            if is_content_type_set and not re.search(
+                "^text/plain(?:;|$)", response.headers["Content-Type"], re.IGNORECASE
+            ):
                 raise ValueError(
                     f"robots.txt has invalid Content-Type {robots_txt_url} {response.headers['Content-Type']}"
                 )


### PR DESCRIPTION
Currently when fetching `robots.txt` files we only accept `text/plain` as a valid `Content-Type` but it's possible for there to be optional details to be present after the content type following a `;` such as a `charset` or `boundary` e.g. `text/html; charset=utf-8`.

To account for this, I've modified the check to be a regexp that matches either exact value `text/plain` or a string starting with that value followed by a `;`, without caring for the casing.

Note this is a little different from the fix proposed in #18 as that only checks the value is _in_ the string which technically means you could get it to pass by including the value in a component e.g. `text/html; text/plain`. While I don't think it's possible to actually exploit this for anything bad (and it might not even be legal), it felt like a good idea given this isn't more complex than not using a regexp