### PR TITLE
fix: track analytics against the base url rather than the url domain

### DIFF
--- a/cwac.py
+++ b/cwac.py
@@ -157,10 +157,7 @@ class CWAC:
                         # Make the URL lowercase
                         dict_row["url"] = self.lowercase_url(dict_row["url"])
 
-                        CWAC.analytics.init_pages_scanned(dict_row["url"])
-
-                        # Add the base_url to analytics.base_urls
-                        CWAC.analytics.base_urls.add(dict_row["url"])
+                        CWAC.analytics.add_base_url(dict_row["url"])
 
                         url_queue.put(dict_row)
 

--- a/src/analytics.py
+++ b/src/analytics.py
@@ -31,17 +31,17 @@ class Analytics:
         self.pages_scanned[base_url] = set()
         self.base_urls.add(base_url)
 
-    def is_url_in_pages_scanned(self, url: str, base_url: str) -> bool:
+    def is_url_in_pages_scanned(self, base_url: str, url: str) -> bool:
         """Return True if the url has been scanned previously for the given base_url."""
         with config.lock:
             return url in self.pages_scanned[base_url]
 
-    def add_page_scanned(self, url: str, base_url: str) -> None:
+    def add_page_scanned(self, base_url: str, url: str) -> None:
         """Log that a page has been scanned.
 
         Args:
-            url (str): The specific URL that was tested
             base_url (str): The base URL that the tested URL came from
+            url (str): The specific URL that was tested
         """
         with config.lock:
             self.total_pages_scanned += 1

--- a/src/analytics.py
+++ b/src/analytics.py
@@ -26,12 +26,10 @@ class Analytics:
         # Store the full set of base_urls
         self.base_urls: set[str] = set()
 
-    def init_pages_scanned(self, base_url: str) -> None:
-        """Init self.pages_scanned dict.
-
-        With the list of base_urls with an empty set as its value.
-        """
+    def add_base_url(self, base_url: str) -> None:
+        """Add base url in preparation of it being scanned."""
         self.pages_scanned[base_url] = set()
+        self.base_urls.add(base_url)
 
     def is_url_in_pages_scanned(self, url: str, base_url: str) -> bool:
         """Return True if the url has been scanned previously for the given base_url."""

--- a/src/analytics.py
+++ b/src/analytics.py
@@ -1,7 +1,6 @@
 """Analytics for the scan."""
 
 import time
-import urllib.parse
 
 import src.output
 from config import config
@@ -27,33 +26,28 @@ class Analytics:
         # Store the full set of base_urls
         self.base_urls: set[str] = set()
 
-    def init_pages_scanned(self, url: str) -> None:
+    def init_pages_scanned(self, base_url: str) -> None:
         """Init self.pages_scanned dict.
 
         With the list of base_urls with an empty set as its value.
         """
-        domain = urllib.parse.urlparse(url).netloc
-        self.pages_scanned[domain] = set()
+        self.pages_scanned[base_url] = set()
 
-    def is_url_in_pages_scanned(self, url: str) -> bool:
-        """Return True if the url has been scanned previously."""
+    def is_url_in_pages_scanned(self, url: str, base_url: str) -> bool:
+        """Return True if the url has been scanned previously for the given base_url."""
         with config.lock:
-            domain = urllib.parse.urlparse(url).netloc
-            return url in self.pages_scanned[domain]
+            return url in self.pages_scanned[base_url]
 
-    def add_page_scanned(self, url: str) -> None:
+    def add_page_scanned(self, url: str, base_url: str) -> None:
         """Log that a page has been scanned.
 
         Args:
-            url (str): The speciifc URL that was tested
+            url (str): The specific URL that was tested
+            base_url (str): The base URL that the tested URL came from
         """
         with config.lock:
             self.total_pages_scanned += 1
-            domain = urllib.parse.urlparse(url).netloc
-            if domain in self.pages_scanned:
-                self.pages_scanned[domain].add(url)
-            else:
-                self.pages_scanned[domain] = {url}
+            self.pages_scanned.setdefault(base_url, set()).add(url)
 
             # Output a progress bar
             src.output.print_progress_bar(
@@ -62,15 +56,14 @@ class Analytics:
                 start_time=self.start_time,
             )
 
-    def record_test_failure(self, url: str) -> None:
+    def record_test_failure(self, base_url: str) -> None:
         """Record a test failure.
 
         Used to adjust est_num_pages_in_test when tests fail.
         """
         with config.lock:
             # Get how many pages were successfully scanned
-            domain = urllib.parse.urlparse(url).netloc
-            self.est_num_pages_in_test -= max(0, config.max_links_per_domain - len(self.pages_scanned[domain]))
+            self.est_num_pages_in_test -= max(0, config.max_links_per_domain - len(self.pages_scanned[base_url]))
 
             # Output a progress bar
             src.output.print_progress_bar(

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -534,8 +534,8 @@ class Crawler:
                 continue
 
             # Check that page has not been scanned before
-            if self.analytics.is_url_in_pages_scanned(url):
-                logging.info("URL has been scanned before %s", url)
+            if self.analytics.is_url_in_pages_scanned(url, base_url):
+                logging.info("URL has been scanned before %s for %s", url, base_url)
                 continue
 
             # Write to audit_log.csv
@@ -547,13 +547,13 @@ class Crawler:
             test_success = audit_manager.run_audits()
 
             if test_success:
-                self.analytics.add_page_scanned(url)
+                self.analytics.add_page_scanned(url, base_url)
                 test_failures = 0
                 pages_scanned += 1
             else:
                 test_failures += 1
                 if test_failures >= 3:
-                    self.analytics.record_test_failure(url)
+                    self.analytics.record_test_failure(base_url)
                     logging.error("Too many sequential test failures, skipping %s", url)
                     return
 

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -534,7 +534,7 @@ class Crawler:
                 continue
 
             # Check that page has not been scanned before
-            if self.analytics.is_url_in_pages_scanned(url, base_url):
+            if self.analytics.is_url_in_pages_scanned(base_url, url):
                 logging.info("URL has been scanned before %s for %s", url, base_url)
                 continue
 
@@ -547,7 +547,7 @@ class Crawler:
             test_success = audit_manager.run_audits()
 
             if test_success:
-                self.analytics.add_page_scanned(url, base_url)
+                self.analytics.add_page_scanned(base_url, url)
                 test_failures = 0
                 pages_scanned += 1
             else:


### PR DESCRIPTION
Currently we use the url domain as the key for analytics, as returned by `urlparse(url).netloc` meaning if scans are done against different paths on the same domain their counts will be merged and that later confuses our verifier since it checks the count for each base url.

By switching to using the base url as our key we avoid this issue, and also can simplify some of the code (though it's about even as we now have to pass the base url into a few places where it wasn't needed previously)