### PR TITLE
ci: setup job for running `pydocstyle`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,20 @@ jobs:
           python-version: '3.12'
       - run: pip install -r requirements.txt
       - run: mypy .
+  pydocstyle:
+    permissions:
+      contents: read # to fetch (actions/checkout)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install -r requirements.txt
+      - run: pydocstyle --convention=google
   install:
     permissions:
       contents: read # to fetch (actions/checkout)


### PR DESCRIPTION
This helps ensure that our code is following the desired convention