### PR TITLE
ci: harden permissions of `isort` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,14 @@ jobs:
       - run: pip install -r requirements.txt
       - run: flake8 --max-line-length 120 .
   isort:
+    permissions:
+      contents: read # to fetch (actions/checkout)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: isort/isort-action@v1
         with:
           requirements-files: "requirements.txt"


### PR DESCRIPTION
I forgot to include this when adding the job originally for some reason 😅 