### PR TITLE
ci: run `pylint`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,20 @@ jobs:
           python-version: '3.12'
       - run: pip install -r requirements.txt
       - run: pydocstyle --convention=google
+  pylint:
+    permissions:
+      contents: read # to fetch (actions/checkout)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install -r requirements.txt
+      - run: pylint -rn -sn $(git ls-files '*.py')
   install:
     permissions:
       contents: read # to fetch (actions/checkout)


### PR DESCRIPTION
This ensures our code is consistent - it feels weird having to do `git ls-files` but it was the only way I could seemingly get `pylint`  to check the whole codebase