### PR TITLE
ci: have dependabot do a single pr for minor and patch updates of tool dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,18 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      tools:
+        patterns:
+          - bandit
+          - black
+          - flake8
+          - flake8-simplify
+          - isort
+          - mypy
+          - pre-commit
+          - pylint
+          - pydocstyle
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
This should give a nicer experience by avoiding long lists of pull requests from dependabot