### PR TITLE
ci: have dependabot do a single pr for minor and patch updates of production dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,7 @@ updates:
         update-types:
           - minor
           - patch
+      production:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
I think this'll be a good idea too - my understanding is that groups are processed top to bottom so we don't need to specify anything else in this group as the `tools` group handles grouping the dependencies we explicitly consider as "tools"