### PR TITLE
feat: support opening `<details>` elements before auditing

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ Field descriptions:
   - Defines which URLs will be scanned when `nocrawl_mode` is `true`
   - a path to a folder that contains CSV files (as many as you like). The CSV files **must** have only one header: url.
   - CWAC will take the URL, and look it up within `base_urls_crawl_path` CSVs to determine the URL's organisation,sector automatically, otherwise 'Unknown' will be specified and a warning is put in the scan's log.
+- `force_open_details_elements`
+  - a boolean value that controls if `<details>` are explicitly marked as `open` before auditing
 - `filter_to_organisations`
   - a list of strings that can be used to restrict a CWAC scan to particular organisations. The organisations are specified in CSVs within the `base_urls` folder
   - e.g. ["Ministry of Social Development", "Department of Internal Affairs"]

--- a/config.py
+++ b/config.py
@@ -45,6 +45,7 @@ class Config:
     viewport_sizes: dict[str, dict[str, int]]
     audit_plugins: dict[str, dict[str, Any]]
     check_for_broken_internal_links: bool
+    force_open_details_elements: bool
 
     # Threading lock (shared amongst all threads)
     lock = threading.RLock()

--- a/config/config_default.json
+++ b/config/config_default.json
@@ -21,6 +21,7 @@
     "base_urls_crawl_path" : "./base_urls/crawl/",
     "base_urls_nocrawl_path": "./base_urls/nocrawl/",
     "check_for_broken_internal_links": false,
+    "force_open_details_elements": true,
     "filter_to_organisations": [],
     "filter_to_domains": [],
     "viewport_sizes": {

--- a/config/config_linux.json
+++ b/config/config_linux.json
@@ -21,6 +21,7 @@
     "base_urls_crawl_path" : "./base_urls/crawl/",
     "base_urls_nocrawl_path": "./base_urls/nocrawl/",
     "check_for_broken_internal_links": true,
+    "force_open_details_elements": true,
     "filter_to_organisations": [],
     "filter_to_domains": [],
     "viewport_sizes": {

--- a/src/audit_manager.py
+++ b/src/audit_manager.py
@@ -139,8 +139,8 @@ class AuditManager:
 
         return status
 
-    def ensure_details_are_open(self) -> None:
-        """Ensure that <details> elements are open so their contents are audited."""
+    def check_for_details_elements(self) -> None:
+        """Check if there are <details> elements that should be opened so their contents are audited."""
         details = self.browser.driver.find_elements(By.TAG_NAME, "details")
 
         if len(details) == 0:
@@ -149,6 +149,11 @@ class AuditManager:
         plural = ""
         if len(details) != 1:
             plural = "s"
+
+        if not config.force_open_details_elements:
+            logging.info("ignoring %i <details> element%s", len(details), plural)
+            return
+
         logging.info("opening %i <details> element%s", len(details), plural)
 
         # Open all <details> elements
@@ -222,7 +227,7 @@ class AuditManager:
                     )
                     continue
 
-                self.ensure_details_are_open()
+                self.check_for_details_elements()
 
                 # Inject the audit ID
                 audit["kwargs"]["audit_id"] = audit_id


### PR DESCRIPTION
This ensures the contents of `<details>` will be audited since the auditors respect the semantic meaning of being opened so will ignore the inner content of the element if they don't have the `open` attribute.

I've tied this to a config option to make it easier to disable since there could be some sites that use JavaScript for opening and closing their `<details>` which get weirded out by this, though in my testing so far it's not come up as a definitely issue which is why I've enabled it by default