### PR TITLE
refactor: define property explicitly to avoid needing to `cast`

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,6 +8,7 @@ import os
 import re
 import sys
 import threading
+import urllib.robotparser
 from typing import Any
 from urllib import parse
 
@@ -47,6 +48,11 @@ class Config:
 
     # Threading lock (shared amongst all threads)
     lock = threading.RLock()
+
+    # global variable to store robots.txt data
+    # the Crawler queries this and populates it
+    # if no entry is found for a website.
+    robots_txt_cache: dict[str, urllib.robotparser.RobotFileParser]
 
     def __init__(self) -> None:
         """Read config.json into self.config."""

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -12,7 +12,7 @@ import time
 import urllib
 import urllib.robotparser
 from queue import SimpleQueue
-from typing import Any, cast
+from typing import Any
 
 import requests
 import selenium.common.exceptions
@@ -431,7 +431,7 @@ class Crawler:
 
         # If the domain is in config.robots_txt_cache, use that
         if domain in config.robots_txt_cache:
-            robot_parser = cast(urllib.robotparser.RobotFileParser, config.robots_txt_cache[domain])
+            robot_parser = config.robots_txt_cache[domain]
             logging.info("Using cached robots.txt for %s", domain)
             result = robot_parser.can_fetch(config.user_agent_product_token, url)
             logging.info("robots.txt result for %s was %s", url, "allow" if result else "disallow")


### PR DESCRIPTION
Turns out we can just do this which makes a lot of sense and frankly it's weird I didn't think to check this first 😅 