### PR TITLE
feat: include organisation and sector when logging the start of testing

### DIFF
--- a/src/crawler.py
+++ b/src/crawler.py
@@ -476,7 +476,7 @@ class Crawler:
             site_data (SiteData): contains info about the site
             base_url (str): the first url to crawl
         """
-        logging.info("Starting crawl %s", base_url)
+        logging.info("Starting to crawl %s", base_url)
 
         # Create an AuditManager instance
         audit_manager = AuditManager(browser=self.browser, analytics=self.analytics)

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -66,7 +66,9 @@ class Crawler:
             with config.lock:
                 site_data = self.url_queue.get()
 
-            logging.info("Starting test %s", site_data["url"])
+            logging.info(
+                "Starting to test %s for %s, %s", site_data["url"], site_data["organisation"], site_data["sector"]
+            )
 
             # Crawl the url (the crawler also initiates tests)
             self.crawl(site_data, site_data["url"])


### PR DESCRIPTION
This should help with associating the logs of a run back to their source - I've also snuck in an improvement to the grammar for a similar line that shows straight after the main one I've modified