### PR TITLE
feat: print exceptions when trying to fetch headers

### DIFF
--- a/src/filters.py
+++ b/src/filters.py
@@ -216,7 +216,7 @@ def process_url_headers(url: str) -> dict[Any, Any]:
             logging.info("%s has status code %i", url, headers.status_code)
             break
         except Exception:  # pylint: disable=broad-except
-            logging.error("Failed to get headers; attempt: %d, %s", i + 1, url)
+            logging.exception("Failed to get headers; attempt: %d, %s", i + 1, url)
             if i == 2:
                 logging.error("Giving up on headers check; attempt: %d, %s", i + 1, url)
                 return output


### PR DESCRIPTION
Currently we're not logging the actual exception which can make it harder to dig into why the headers request failed