### PR TITLE
feat: support specifying URLs that don't support HEAD requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ results/*
 !/base_urls/crawl/example.txt
 /base_urls/nocrawl/*
 !/base_urls/nocrawl/example.txt
+/base_urls/nohead/*
+!/base_urls/nohead/example.txt
 /base_urls/store/*
 !/base_urls/store/.gitkeep
 /reports/*

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Field descriptions:
   - a path to a folder that contains CSV files (as many as you like). The CSV files **must** have only one header: url.
   - CWAC will take the URL, and look it up within `base_urls_crawl_path` CSVs to determine the URL's organisation,sector automatically, otherwise 'Unknown' will be specified and a warning is put in the scan's log.
 - `base_urls_nohead_path`
-  - Defines which URLs that don't support HEAD requests 
+  - Defines which URLs don't support HEAD requests 
   - a path to a folder that contains CSV files (as many as you like). The CSV files **must** have only one header: url.
   - In cases where a HEAD request would be made CWAC will instead make a GET request
 - `force_open_details_elements`

--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ Field descriptions:
   - Defines which URLs will be scanned when `nocrawl_mode` is `true`
   - a path to a folder that contains CSV files (as many as you like). The CSV files **must** have only one header: url.
   - CWAC will take the URL, and look it up within `base_urls_crawl_path` CSVs to determine the URL's organisation,sector automatically, otherwise 'Unknown' will be specified and a warning is put in the scan's log.
+- `base_urls_nohead_path`
+  - Defines which URLs that don't support HEAD requests 
+  - a path to a folder that contains CSV files (as many as you like). The CSV files **must** have only one header: url.
+  - In cases where a HEAD request would be made CWAC will instead make a GET request
 - `force_open_details_elements`
   - a boolean value that controls if `<details>` are explicitly marked as `open` before auditing
 - `filter_to_organisations`

--- a/base_urls/nohead/example.txt
+++ b/base_urls/nohead/example.txt
@@ -1,0 +1,13 @@
+# Place URLs in CSV files within /base_urls/nohead/
+# and the CWAC will avoid making HEAD requests to
+# those websites if they are listed in /base_urls/crawl/
+
+# You can place multiple CSV files into the /base_urls/nohead/ folder
+# and they will all be loaded.
+
+# Below is an example of the expected format of CSV files:
+
+url
+https://www.put-target-domain-name-here.govt.nz/
+https://www.put-another-target-domain-name-here.govt.nz/
+https://www.put-yet-another-target-domain-name-here.govt.nz/

--- a/config.py
+++ b/config.py
@@ -41,6 +41,7 @@ class Config:
     shuffle_base_urls: bool
     base_urls_crawl_path: str
     base_urls_nocrawl_path: str
+    base_urls_nohead_path: str
     filter_to_organisations: list[str]
     filter_to_domains: list[str]
     viewport_sizes: dict[str, dict[str, int]]
@@ -101,6 +102,10 @@ class Config:
         # Ensure base_url_nocrawl_path is within base_urls folder
         if not self.is_path_subdir(self.config["base_urls_nocrawl_path"], "./base_urls"):
             raise ValueError("base_urls_nocrawl_path must be within base_urls folder")
+
+        # Ensure base_urls_nohead_path is within base_urls folder
+        if not self.is_path_subdir(self.config["base_urls_nohead_path"], "./base_urls"):
+            raise ValueError("base_urls_nohead_path must be within base_urls folder")
 
         self.config["url_lookup"] = self.import_url_lookup_files()
 

--- a/config/config_default.json
+++ b/config/config_default.json
@@ -20,6 +20,7 @@
     "shuffle_base_urls": true,
     "base_urls_crawl_path" : "./base_urls/crawl/",
     "base_urls_nocrawl_path": "./base_urls/nocrawl/",
+    "base_urls_nohead_path": "./base_urls/nohead/",
     "check_for_broken_internal_links": false,
     "force_open_details_elements": true,
     "filter_to_organisations": [],

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -12,7 +12,7 @@ import time
 import urllib
 import urllib.robotparser
 from queue import SimpleQueue
-from typing import Any, Literal
+from typing import Any, TypedDict
 
 import requests
 import selenium.common.exceptions
@@ -37,7 +37,14 @@ from src.output import CSVWriter
 # disable too-many-locals
 # pylint: disable=R0914
 
-type SiteData = dict[Literal["organisation", "url", "sector"], str]
+
+class SiteData(TypedDict):
+    """Holds data for a site that should be crawled and audited."""
+
+    organisation: str
+    url: str
+    sector: str
+    supports_head: bool
 
 
 class Crawler:
@@ -302,7 +309,7 @@ class Crawler:
         self,
         audit_manager: AuditManager,
         new_link: str,
-        site_data: dict[Any, Any],
+        site_data: SiteData,
     ) -> None:
         """Register audit plugins with AuditManager.
 
@@ -523,7 +530,7 @@ class Crawler:
             # status_code and final_url after redirects
             # status_code is None if an error occurred
             if config.perform_header_check:
-                url_data = src.filters.process_url_headers(url)
+                url_data = src.filters.process_url_headers(url, supports_head_requests=site_data["supports_head"])
                 url_status_code = url_data["status_code"]
                 url = url_data["final_url"]
                 if not self.are_url_headers_acceptable(


### PR DESCRIPTION
As some sites don't like HEAD requests, it's useful to provide an auxiliary list of URLs for which CWAC should use GET in place of HEAD which this enables in a manner similar to the exiting `nocrawl` feature.

The actual support for HEAD requests is included as part of the general site data which gets passed around, which I think could be useful in future for similar site-specific options to decouple the classes from each other a bit more