### PR TITLE
Update config_linux.json

### DIFF
--- a/config/config_linux.json
+++ b/config/config_linux.json
@@ -20,6 +20,7 @@
     "shuffle_base_urls": true,
     "base_urls_crawl_path" : "./base_urls/crawl/",
     "base_urls_nocrawl_path": "./base_urls/nocrawl/",
+    "base_urls_nohead_path": "./base_urls/nohead/",
     "check_for_broken_internal_links": true,
     "force_open_details_elements": true,
     "filter_to_organisations": [],


### PR DESCRIPTION
Adds base_urls_nohead_path to config_linux, which was missing this.