### PR TITLE
ci: explicitly exclude tooling packages from `production` update group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,16 @@ updates:
           - minor
           - patch
       production:
+        exclude-patterns:
+          - bandit
+          - black
+          - flake8
+          - flake8-simplify
+          - isort
+          - mypy
+          - pre-commit
+          - pylint
+          - pydocstyle
         update-types:
           - minor
           - patch


### PR DESCRIPTION
It seems that there's an implicit rule with groups that there be more than one dependency update since dependabot has created #89 even though `flake8` is in the `tools` group.

This might actually be a bug in dependabot but for now I've just explicitly listed all the tooling packages as excluded from the `production` group