### PR TITLE
feat: replace `[output_report_name]` placeholder with `[YYYY-MM-DD]` in report config

### DIFF
--- a/export_report_data.py
+++ b/export_report_data.py
@@ -13,7 +13,7 @@ from typing import Any, cast
 
 import pandas as pd
 
-TODAY = str(date.today())
+TODAY = date.today().strftime("%Y-%m-%d")
 
 
 class DataExporter:
@@ -184,7 +184,7 @@ class DataExporter:
             print(f"Exporting {export_format['export_type']} to {self.config['output_report_name']}")
 
             # Perform string subs for output filename (include output_report_name in all files)
-            export_format["output_filename"] = export_format["output_filename"].replace("[output_report_name]", TODAY)
+            export_format["output_filename"] = export_format["output_filename"].replace("[YYYY-MM-DD]", TODAY)
             # Check if export_format["input_filename"] exists
             if "input_filename" in export_format and not os.path.exists(
                 self.input_path + export_format["input_filename"]

--- a/export_report_data_config.json
+++ b/export_report_data_config.json
@@ -6,64 +6,64 @@
             "enabled": true,
             "export_type": "generate_axe_core_template_aware_file",
             "input_filename": "axe_core_audit.csv",
-            "output_filename": "[output_report_name]_axe_core_audit_template_aware.csv"
+            "output_filename": "[YYYY-MM-DD]_axe_core_audit_template_aware.csv"
         },
         {
             "enabled": true,
             "export_type": "axe_core_template_aware_leaderboard",
             "input_filename": "axe_core_audit.csv",
-            "output_filename": "[output_report_name]_axe_core_audit_leaderboard.csv"
+            "output_filename": "[YYYY-MM-DD]_axe_core_audit_leaderboard.csv"
         },
         {
             "enabled": true,
             "export_type": "leaderboard",
             "input_filename": "focus_indicator_audit.csv",
-            "output_filename": "[output_report_name]_focus_indicator_audit_leaderboard.csv",
+            "output_filename": "[YYYY-MM-DD]_focus_indicator_audit_leaderboard.csv",
             "query": "SELECT organisation, base_url, SUM(num_issues) as num_issues FROM cwac_table GROUP BY base_url ORDER BY num_issues DESC"
         },
         {
             "enabled": true,
             "export_type": "leaderboard",
             "input_filename": "reflow_audit.csv",
-            "output_filename": "[output_report_name]_reflow_audit_leaderboard.csv",
+            "output_filename": "[YYYY-MM-DD]_reflow_audit_leaderboard.csv",
             "query": "SELECT organisation, base_url, AVG(overflow_amount_px) AS overflow_amount_px FROM cwac_table GROUP BY base_url ORDER BY overflow_amount_px DESC;"
         },
         {
             "enabled": true,
             "export_type": "leaderboard",
             "input_filename": "language_audit.csv",
-            "output_filename": "[output_report_name]_language_audit_leaderboard.csv",
+            "output_filename": "[YYYY-MM-DD]_language_audit_leaderboard.csv",
             "query": "SELECT organisation, base_url, AVG(smog_gl) AS smog_grade_level FROM cwac_table GROUP BY base_url ORDER BY smog_grade_level DESC"
         },
         {
             "enabled": true,
             "export_type": "raw_data",
             "input_filename": "axe_core_audit.csv",
-            "output_filename": "[output_report_name]_axe_core_audit.csv"
+            "output_filename": "[YYYY-MM-DD]_axe_core_audit.csv"
         },
         {
             "enabled": true,
             "export_type": "raw_data",
             "input_filename": "axe_core_audit_template_aware.csv",
-            "output_filename": "[output_report_name]_axe_core_audit_template_aware.csv"
+            "output_filename": "[YYYY-MM-DD]_axe_core_audit_template_aware.csv"
         },
         {
             "enabled": true,
             "export_type": "raw_data",
             "input_filename": "focus_indicator_audit.csv",
-            "output_filename": "[output_report_name]_focus_indicator_audit.csv"
+            "output_filename": "[YYYY-MM-DD]_focus_indicator_audit.csv"
         },
         {
             "enabled": true,
             "export_type": "raw_data",
             "input_filename": "reflow_audit.csv",
-            "output_filename": "[output_report_name]_reflow_audit.csv"
+            "output_filename": "[YYYY-MM-DD]_reflow_audit.csv"
         },
         {
             "enabled": true,
             "export_type": "raw_data",
             "input_filename": "language_audit.csv",
-            "output_filename": "[output_report_name]_language_audit.csv"
+            "output_filename": "[YYYY-MM-DD]_language_audit.csv"
         }
     ]
 }


### PR DESCRIPTION
The current placeholder name is the same as an existing property in the config but confusingly the placeholder is replaced with a date rather than that properties value, so to clear that up this changes the placeholder to be `YYYY-MM-DD`.

While this could confuse people into thinking they can use other date formats, I think it's still a lot better than what we have currently.

I have also changed how we get the date to ensure it is in the `YYYY-MM-DD` format as I suspect currently its actually system dependent and this gives a more reproducible outcome across different devices 