### PR TITLE
feat: take input results folder name as first argument to exporter, and use that as the report folder name

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,9 +231,7 @@ You can either use the raw data stored in teh `./results/` folder directly, or y
 
 The CWAC data exporter is in the file `export_report_data.py`, and its configuration is in `export_report_data_config.json`.
 
-To use the CWAC data exporter, first modify `export_report_data_config.json` to specify where it should import data from within the `./results/` folder. Set `input_results_folder_name` to a valid folder name found within `./results/`.
-
-You can then run `export_report_data.py` and it will generate various leaderboard CSVs etc and the output will be placed within `./reports/{input_results_folder_name}/`.
+To use the CWAC data exporter, run `python export_report_data.py` passing it the name of a folder in the `./results/` folder, and it will generate various leaderboard CSVs etc and the output will be placed within `./reports/`.
 
 ## Checking CWAC's source code
 

--- a/export_report_data.py
+++ b/export_report_data.py
@@ -8,6 +8,7 @@ To configure the export, edit export_report_data_config.json.
 import json
 import os
 import sqlite3
+import sys
 from typing import Any, cast
 
 import pandas as pd
@@ -19,8 +20,11 @@ class DataExporter:
     def __init__(self) -> None:
         """Init vars."""
         self.config = self.import_config_file()
-        self.input_path = "./results/" + self.config["input_results_folder_name"] + "/"
-        self.output_path = "./reports/" + self.config["input_results_folder_name"] + "/"
+
+        input_results_folder_name = self.__determine_results_folder_name()
+
+        self.input_path = "./results/" + input_results_folder_name + "/"
+        self.output_path = "./reports/" + input_results_folder_name + "/"
         # assert the input_path exists
         if not os.path.exists(self.input_path):
             raise FileNotFoundError(f"Input path {self.input_path} does not exist.")
@@ -28,6 +32,11 @@ class DataExporter:
         if not os.path.exists(self.output_path):
             os.makedirs(self.output_path)
         self.iterate_export_formats()
+
+    def __determine_results_folder_name(self) -> str:
+        if len(sys.argv) <= 1:
+            raise ValueError("First argument is required and should be the name of a folder in ./results/")
+        return sys.argv[1]
 
     # noinspection PyDefaultArgument
     def sort_with_default(self, df: pd.DataFrame, columns: list[str]) -> pd.DataFrame:

--- a/export_report_data_config.json
+++ b/export_report_data_config.json
@@ -1,5 +1,4 @@
 {
-    "input_results_folder_name": "input_results_folder_name",
     "export_formats": [
         {
             "enabled": true,


### PR DESCRIPTION
As we don't expect there to be a situation in which the latest report generated for a particular result isn't what you want to use, we can drop support for configuring the output folder name in favor of just using the same name as the input folder - this makes it both easier to manage result/report pairs and easier to use the exporter since we can take the input path as an argument similar to how the auditor works.

This is an example of the structure now using the default config:

```
cwac on  report/redo [?] via  v20.19.0 via 🐍 v3.12.10
❯ python ./export_report_data.py 2025-07-09_10-32-13_my_audit
Exporting generate_axe_core_template_aware_file to ./reports/2025-07-09_10-32-13_my_audit/
Exporting axe_core_template_aware_leaderboard to ./reports/2025-07-09_10-32-13_my_audit/
Exporting leaderboard to ./reports/2025-07-09_10-32-13_my_audit/
WARNING: File ./results/2025-07-09_10-32-13_my_audit/focus_indicator_audit.csv does not exist.
Exporting leaderboard to ./reports/2025-07-09_10-32-13_my_audit/
Exporting leaderboard to ./reports/2025-07-09_10-32-13_my_audit/
Exporting raw_data to ./reports/2025-07-09_10-32-13_my_audit/
Exporting raw_data to ./reports/2025-07-09_10-32-13_my_audit/
Exporting raw_data to ./reports/2025-07-09_10-32-13_my_audit/
WARNING: File ./results/2025-07-09_10-32-13_my_audit/focus_indicator_audit.csv does not exist.
Exporting raw_data to ./reports/2025-07-09_10-32-13_my_audit/
Exporting raw_data to ./reports/2025-07-09_10-32-13_my_audit/

cwac on  report/redo [?] via  v20.19.0 via 🐍 v3.12.10
❯ tree reports/
reports/
└── 2025-07-09_10-32-13_my_audit
    ├── axe_core_audit.csv
    ├── axe_core_audit_leaderboard.csv
    ├── axe_core_audit_template_aware.csv
    ├── language_audit.csv
    ├── language_audit_leaderboard.csv
    ├── reflow_audit.csv
    └── reflow_audit_leaderboard.csv

1 directory, 7 files
```

In future, we might even want to look at defaulting to the latest result if argument is given as that'd make it even easier to run.

As discussed in https://github.com/GOVTNZ/cwac/pull/103#issuecomment-3050876927
Closes #103
Closes #15