### PR TITLE
feat: support prefixing report output files

### DIFF
--- a/export_report_data.py
+++ b/export_report_data.py
@@ -31,6 +31,7 @@ class DataExporter:
         # create ouptut folder if it doesn't exist
         if not os.path.exists(self.output_path):
             os.makedirs(self.output_path)
+        self.output_prefix = self.output_path + self.config["output_filename_prefix"]
         self.iterate_export_formats()
 
     def __determine_results_folder_name(self) -> str:
@@ -180,7 +181,7 @@ class DataExporter:
         """
         with (
             open(self.input_path + input_filename, "r", encoding="utf-8-sig") as input_file,
-            open(self.output_path + output_filename, "w", encoding="utf-8-sig") as output_file,
+            open(self.output_prefix + output_filename, "w", encoding="utf-8-sig") as output_file,
         ):
             output_file.write(input_file.read())
 
@@ -214,7 +215,7 @@ class DataExporter:
 
                 # Write leaderboard to CSV
                 output_df.to_csv(
-                    self.output_path + export_format["output_filename"],
+                    self.output_prefix + export_format["output_filename"],
                     index=False,
                 )
 
@@ -243,7 +244,7 @@ class DataExporter:
 
                 # Write the leaderboard to a CSV file
                 leaderboard_df.to_csv(
-                    self.output_path + export_format["output_filename"],
+                    self.output_prefix + export_format["output_filename"],
                     index=False,
                 )
 

--- a/export_report_data_config.json
+++ b/export_report_data_config.json
@@ -1,4 +1,5 @@
 {
+    "output_filename_prefix": "",
     "export_formats": [
         {
             "enabled": true,


### PR DESCRIPTION
Example of output with a value of `my_prefix_`:

```
cwac on  report/prefix [!?] via  v20.19.0 via 🐍 v3.12.10
❯ python ./export_report_data.py 2025-07-09_10-32-13_my_audit
Exporting generate_axe_core_template_aware_file to ./reports/2025-07-09_10-32-13_my_audit/
Exporting axe_core_template_aware_leaderboard to ./reports/2025-07-09_10-32-13_my_audit/
Exporting leaderboard to ./reports/2025-07-09_10-32-13_my_audit/
WARNING: File ./results/2025-07-09_10-32-13_my_audit/focus_indicator_audit.csv does not exist.
Exporting leaderboard to ./reports/2025-07-09_10-32-13_my_audit/
Exporting leaderboard to ./reports/2025-07-09_10-32-13_my_audit/
Exporting raw_data to ./reports/2025-07-09_10-32-13_my_audit/
Exporting raw_data to ./reports/2025-07-09_10-32-13_my_audit/
Exporting raw_data to ./reports/2025-07-09_10-32-13_my_audit/
WARNING: File ./results/2025-07-09_10-32-13_my_audit/focus_indicator_audit.csv does not exist.
Exporting raw_data to ./reports/2025-07-09_10-32-13_my_audit/
Exporting raw_data to ./reports/2025-07-09_10-32-13_my_audit/

cwac on  report/prefix [!?] via  v20.19.0 via 🐍 v3.12.10
❯ tree reports/
reports/
└── 2025-07-09_10-32-13_my_audit
    ├── my_prefix_axe_core_audit.csv
    ├── my_prefix_axe_core_audit_leaderboard.csv
    ├── my_prefix_axe_core_audit_template_aware.csv
    ├── my_prefix_language_audit.csv
    ├── my_prefix_language_audit_leaderboard.csv
    ├── my_prefix_reflow_audit.csv
    └── my_prefix_reflow_audit_leaderboard.csv

1 directory, 7 files
```

Resolves #109