### PR TITLE
fix: don't require language to be both "en" and start with "en-"

### DIFF
--- a/src/audit_plugins/language_audit.py
+++ b/src/audit_plugins/language_audit.py
@@ -57,7 +57,7 @@ class LanguageAudit:
         """
         lang = self.__get_document_lang()
 
-        if lang != "en" or not lang.startswith("en-"):
+        if lang != "en" and not lang.startswith("en-"):
             logging.warning("Test can only be run on English pages but lang for this page is %s: %s", lang, self.url)
             return True
 


### PR DESCRIPTION
Currently we're rejecting every site as not being in English 😓 