### PR TITLE
feat: improve wording and skip getting extra links when set to visit a max of 1 link per domain or in nocrawl mode

### DIFF
--- a/cwac.py
+++ b/cwac.py
@@ -240,8 +240,12 @@ class CWAC:
         # Import base_urls into global varaiable
         CWAC.url_queue = self.import_base_urls()
 
+        things_to_scan = "websites"
+        if config.max_links_per_domain == 1:
+            things_to_scan = "pages"
+
         # Print the number of URLs to be scanned
-        num_websites_msg = f"Number of websites to be scanned: {CWAC.url_queue.qsize()}"
+        num_websites_msg = f"Number of {things_to_scan} to be scanned: {CWAC.url_queue.qsize()}"
         print(num_websites_msg)
         print("*" * 80)
         logging.info(num_websites_msg)

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -598,7 +598,7 @@ class Crawler:
 
         self.analytics.record_test_failure(base_url)
         self.record_pages_scanned(site_data, pages_scanned)
-        if config.max_links_per_domain == 1:
+        if config.max_links_per_domain != 1:
             logging.info("Crawl exhausted all links %s", base_url)
 
     def record_pages_scanned(self, site_data: SiteData, pages_scanned: int) -> None:

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -581,6 +581,10 @@ class Crawler:
                     logging.error("Too many sequential test failures, skipping %s", url)
                     return
 
+            # don't bother getting links if we are only scanning one link per base url
+            if config.max_links_per_domain == 1:
+                break
+
             links = self.get_links(base_url, url)
 
             # Add all links to the queue

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -481,7 +481,10 @@ class Crawler:
             site_data (SiteData): contains info about the site
             base_url (str): the first url to crawl
         """
-        logging.info("Starting crawl %s", base_url)
+        action = "crawl"
+        if config.max_links_per_domain == 1:
+            action = "audit"
+        logging.info("Starting %s of %s", action, base_url)
 
         # Create an AuditManager instance
         audit_manager = AuditManager(browser=self.browser, analytics=self.analytics)
@@ -595,7 +598,8 @@ class Crawler:
 
         self.analytics.record_test_failure(base_url)
         self.record_pages_scanned(site_data, pages_scanned)
-        logging.info("Crawl exhausted all links %s", base_url)
+        if config.max_links_per_domain == 1:
+            logging.info("Crawl exhausted all links %s", base_url)
 
     def record_pages_scanned(self, site_data: SiteData, pages_scanned: int) -> None:
         """Record the number of pages that were scanned for the site."""


### PR DESCRIPTION
Having "nocrawl" mode enabled overrides the max number of links to visit per domain to be 1, but the current log messages still give the impression that the sites might have been crawled, and we in fact do still spend time extracting links for crawling even though we'll never use them.

Now when the max number of links to visit per domain is 1 we skip getting more links and use different language to make it clearer we're only interacting with the specific URLs in the url CSVs.

Note I've purposely based the logic off the value of `max_links_per_domain` rather than `nocrawl_mode` as the latter mainly just results in the former being set to 1 and I suspect should probably be removed in favor of having people do that themselves which I plan to explore as a follow-up.

The config variable should also probably be renamed as its not really "per domain" but "per base url"

Resolves #104