### PR TITLE
feat: allow using a CSS selector to target content for focus audits

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ The format of `audit_plugin` entries requires a snake case name as the key, and 
     "focus_indicator_audit": {
         "class_name": "FocusIndicatorAudit",
         "enabled": true,
+        "root_element_css_selector": "main",
         "pre_tab_key_presses": 0,
         "max_tab_key_presses": 15
     },

--- a/config/config_default.json
+++ b/config/config_default.json
@@ -47,6 +47,7 @@
         "focus_indicator_audit": {
             "class_name": "FocusIndicatorAudit",
             "enabled": false,
+            "root_element_css_selector": "main",
             "pre_tab_key_presses": 0,
             "max_tab_key_presses": 5
         },


### PR DESCRIPTION
This should increase the likelihood of getting a meaningful result from the focus indicator without requiring a large amount of tabbing (which is expensive) - I've used `main` as the default selector as that element should be unique and not include things like sidebars, logos, and search forms which are common at the start of documents and so can consume tabs.

In the case that the selector does not match an element, we fallback to the `body` element to mirror current behaviour, though it could be worth having another config variable to control this as there might be cases where it'd be preferable for the auditor to fail or skip itself e.g. if you're wanting say "check the focus on all pages that have a `<nav>`" without explicitly determining what pages actually do.

Relates to #95