### PR TITLE
feat: replace "crawl" with "visit"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@ config/
 !config/config_default.json
 !/drivers/.gitkeep
 .vscode/
-/base_urls/crawl/*
-!/base_urls/crawl/example.txt
+/base_urls/visit/*
+!/base_urls/visit/example.txt
 /base_urls/nohead/*
 !/base_urls/nohead/example.txt
 /base_urls/store/*

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ CWAC is a tool that can scan hundreds of websites for accessibility issues, auto
 
 CWAC can be used as a mechanism to monitor the New Zealand Government's implementation of minimum accessibility standards and guidelines on its websites. The primary standard, is the [NZ Government Web Accessibility Standard](https://www.digital.govt.nz/standards-and-guidance/nz-government-web-standards/web-accessibility-standard-1-1/), which includes [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/WCAG21/) Level AA conformance. CWAC enables the partial fulfillment of [Article 9 of the United Nations Convention on the Rights of Persons with Disabilities (CRPD)](https://www.un.org/development/desa/disabilities/convention-on-the-rights-of-persons-with-disabilities/article-9-accessibility.html).
 
-Provided a list of URLs, CWAC automatically crawls a specified number of pages per URL, and checks each page for automatically-identifiable accessibility issues. It then stores results in an easy-to-read CSV file.
+Provided a list of URLS to visit, CWAC will check each page for automatically-identifiable accessibility issues and store the results in an easy-to-read CSV file.
 
-CWAC can also crawl an explicitly-defined set of URLs without a crawler, which is useful for re-running tests to see changes in accessibility conformance over time.
+CWAC can also crawl each page as it goes to determine additional pages to check (up to a set max number per URL), respecting `robots.txt` and server signals when doing so. This makes it easy to check entire sites without knowing the all paths beforehand.
 
 CWAC is designed to be extensible, so new forms of web testing can be added over time. For instance, CWAC could also run [The Nu Html Checker](https://github.com/validator) on web pages. Or, it could theoretically check other website requirements, such as website data usage and performance, or the existence of a privacy or copyright statement.
 

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ Field descriptions:
 - `headless`
   - a boolean that specifies whether the browsers will be headless, or not (browser windows will be invisible)
 - `max_links_per_domain`
-  - the maximum number of pages that will be tested for each URL specified in `base_urls_crawl_path`
-  - if set to 1 then pages will just be visited rather than crawled for additional links
+  - the maximum number of pages that will be tested for each URL specified in `base_urls_visit_path`
+  - if set to 1 then pages will just be visited without any crawling for additional links
 - `thread_count`
   - the number of browsers, and threads CWAC will use
   - a number equal to the number of CPU cores is most efficient
@@ -158,10 +158,10 @@ Field descriptions:
   - a boolean value that determines if CWAC will send a header-only request to each URL before loading the URL in a browser. This can prevent Chrome from loading garbage URLs, but it also slows down the crawler, and increases network requests.
 - `shuffle_base_urls`
   - before CWAC starts scanning websites, it will randomly shuffle the order of URLs it will scan
-- `base_urls_crawl_path`
+- `base_urls_visit_path`
   - Defines which URLs will be scanned
   - a path to a folder that contains CSV files (as many as you like). The CSV files **must** have the headers: organisation,url,sector.
-  - The entries in `base_urls_crawl_path` are extremely important, as these files are used to associate URLs with other information like their organisation, and sector
+  - The entries in `base_urls_visit_path` are extremely important, as these files are used to associate URLs with other information like their organisation, and sector
 - `base_urls_nohead_path`
   - Defines which URLs don't support HEAD requests 
   - a path to a folder that contains CSV files (as many as you like). The CSV files **must** have only one header: url.
@@ -173,7 +173,7 @@ Field descriptions:
   - e.g. ["Ministry of Social Development", "Department of Internal Affairs"]
   - partial string matches are included, e.g. "Internal" would match "Department of Internal Affairs"
 - `filter_to_domains`
-  - a list of strings of specific URLs to restrict a crawl to (these URLs *must* be specified within a CSV inside of `base_urls_crawl_path`)
+  - a list of strings of specific URLs to limit CWAC to (these URLs *must* be specified within a CSV inside of `base_urls_visit_path`)
   - e.g. ["https://msd.govt.nz/", "https://dia.govt.nz"]
   - partial string matches are included e.g. "dia.govt" matches "https://dia.govt.nz"
 - `viewport_sizes`

--- a/base_urls/nohead/example.txt
+++ b/base_urls/nohead/example.txt
@@ -1,6 +1,6 @@
 # Place URLs in CSV files within /base_urls/nohead/
 # and the CWAC will avoid making HEAD requests to
-# those websites if they are listed in /base_urls/crawl/
+# those websites if they are listed in /base_urls/visit/
 
 # You can place multiple CSV files into the /base_urls/nohead/ folder
 # and they will all be loaded.

--- a/base_urls/visit/example.txt
+++ b/base_urls/visit/example.txt
@@ -1,7 +1,7 @@
-# Place URLs in CSV files within /base_urls/crawl/
-# and CWAC will crawl those specified websites.
+# Place URLs in CSV files within /base_urls/visit/
+# and CWAC will visit those specified URls.
 
-# You can place multiple CSV files into the /base_urls/crawl/ folder
+# You can place multiple CSV files into the /base_urls/visit/ folder
 # and they will all be loaded.
 
 # Below is an example of the expected format of CSV files:

--- a/config.py
+++ b/config.py
@@ -39,7 +39,7 @@ class Config:
     only_allow_https: bool
     perform_header_check: bool
     shuffle_base_urls: bool
-    base_urls_crawl_path: str
+    base_urls_visit_path: str
     base_urls_nohead_path: str
     filter_to_organisations: list[str]
     filter_to_domains: list[str]
@@ -96,9 +96,9 @@ class Config:
 
         self.__resolve_automatic_settings()
 
-        # Ensure base_url_crawl_path is within base_urls folder
-        if not self.is_path_subdir(self.config["base_urls_crawl_path"], "./base_urls"):
-            raise ValueError("base_urls_crawl_path must be within base_urls folder")
+        # Ensure base_urls_visit_path is within base_urls folder
+        if not self.is_path_subdir(self.config["base_urls_visit_path"], "./base_urls"):
+            raise ValueError("base_urls_visit_path must be within base_urls folder")
 
         # Ensure base_urls_nohead_path is within base_urls folder
         if not self.is_path_subdir(self.config["base_urls_nohead_path"], "./base_urls"):
@@ -237,7 +237,7 @@ class Config:
         }
 
     def import_url_lookup_files(self) -> dict[str, dict[str, str]]:
-        """Import all CSV files in base_urls_crawl_path.
+        """Import all CSV files in base_urls_visit_path.
 
         This data is primarily used for looking up the agency details
         given a URL by using the lookup_organisation() method.
@@ -249,10 +249,10 @@ class Config:
         """
         base_urls: dict[str, dict[str, str]] = {}
 
-        for filename in os.listdir(self.config["base_urls_crawl_path"]):
+        for filename in os.listdir(self.config["base_urls_visit_path"]):
             if filename.endswith(".csv"):
                 with open(
-                    os.path.join(self.config["base_urls_crawl_path"], filename),
+                    os.path.join(self.config["base_urls_visit_path"], filename),
                     encoding="utf-8-sig",
                     newline="",
                 ) as file:
@@ -261,7 +261,7 @@ class Config:
                     for row in reader:
                         if len(row) != 3:
                             raise ValueError(
-                                "crawl_path_to_audit_log CSV files must have 3 columns",
+                                "CSV files must have 3 columns",
                                 row,
                                 filename,
                             )

--- a/config/config_default.json
+++ b/config/config_default.json
@@ -17,7 +17,7 @@
     "only_allow_https": true,
     "perform_header_check": true,
     "shuffle_base_urls": true,
-    "base_urls_crawl_path" : "./base_urls/crawl/",
+    "base_urls_visit_path" : "./base_urls/visit/",
     "base_urls_nohead_path": "./base_urls/nohead/",
     "check_for_broken_internal_links": true,
     "force_open_details_elements": true,

--- a/cwac.py
+++ b/cwac.py
@@ -178,15 +178,15 @@ class CWAC:
         return base_urls
 
     def import_base_urls(self) -> SimpleQueue[SiteData]:
-        """Import target URLs for crawl mode.
+        """Import target URLs to visit and potentially crawl.
 
-        This function reads all CSVs in config.base_urls_crawl_path
+        This function reads all CSVs in config.base_urls_visit_path
         and returns a SimpleQueue of each row
 
         Returns:
             SimpleQueue: a SimpleQueue of URLs
         """
-        folder_path = config.base_urls_crawl_path
+        folder_path = config.base_urls_visit_path
 
         headless_base_urls = self.import_base_urls_without_head_support()
 

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -473,9 +473,11 @@ class Crawler:
     def crawl(self, site_data: SiteData, base_url: str) -> None:
         """Crawls a domain and executes the AuditManager.
 
-        Loads a webpage, and runs a set of tests on that page. It also
-        scrapes the links out of the page, and navigates to new pages,
-        effectively crawling the website.
+        Loads a webpage, and runs a set of tests on that page. If
+        configured to visit more than one link per domain, it also
+        scrapes new links out of the page which are then navigated
+        to for further testing and scraping, effectively crawling
+        the website.
 
         Args:
             site_data (SiteData): contains info about the site
@@ -483,7 +485,7 @@ class Crawler:
         """
         action = "crawl"
         if config.max_links_per_domain == 1:
-            action = "audit"
+            action = "visit"
         logging.info("Starting %s of %s", action, base_url)
 
         # Create an AuditManager instance

--- a/src/output.py
+++ b/src/output.py
@@ -150,7 +150,7 @@ def output_init_message() -> None:
     print_log(f"Only allow HTTPS: {config.only_allow_https}")
     print_log(f"Perform header checks: {config.perform_header_check}")
     print_log(f"Shuffle base urls: {config.shuffle_base_urls}")
-    print_log(f"Base urls crawl path: {config.base_urls_crawl_path}")
+    print_log(f"Base urls visit path: {config.base_urls_visit_path}")
     print_log(f"Check for broken internal links: {config.check_for_broken_internal_links}")
     print_log("*" * 80)
 


### PR DESCRIPTION
Following on from #116 this replaces the "crawl" terminology with "visit" since that's the primary functionality of the tool, with crawling being a secondary functionality to make it easier to cover sections of sites