### PR TITLE
docs: replace `filter_to_urls` with `filter_to_domains`

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Field descriptions:
   - a list of strings that can be used to restrict a CWAC scan to particular organisations. The organisations are specified in CSVs within the `base_urls` folder
   - e.g. ["Ministry of Social Development", "Department of Internal Affairs"]
   - partial string matches are included, e.g. "Internal" would match "Department of Internal Affairs"
-- `filter_to_urls`
+- `filter_to_domains`
   - a list of strings of specific URLs to restrict a crawl to (these URLs *must* be specified within a CSV inside of `base_urls_crawl_path`)
   - e.g. ["https://msd.govt.nz/", "https://dia.govt.nz"]
   - partial string matches are included e.g. "dia.govt" matches "https://dia.govt.nz"


### PR DESCRIPTION
I'm guessing this got renamed at some point 🤷 