### PR TITLE
refactor: have audit plugins extend the default audit

### DIFF
--- a/src/audit_plugins/axe_core_audit.py
+++ b/src/audit_plugins/axe_core_audit.py
@@ -144,7 +144,7 @@ class AxeCoreAudit(DefaultAudit):
             return False
 
         # Get page information from DefaultAudit
-        default_audit_row = super().run()[0]
+        default_audit_row = self._default_audit_row
 
         expanded_results = self.run_generate_expanded_results(axe_core_results)
 

--- a/src/audit_plugins/axe_core_audit.py
+++ b/src/audit_plugins/axe_core_audit.py
@@ -15,23 +15,17 @@ from src.audit_manager import AuditManager
 from src.audit_plugins.default_audit import DefaultAudit
 from src.browser import Browser
 
-# pylint: disable=too-many-instance-attributes
 
-
-class AxeCoreAudit:
+class AxeCoreAudit(DefaultAudit):
     """axe-core audit."""
 
     audit_type = "AxeCoreAudit"
 
     def __init__(self, browser: Browser, **kwargs: Any) -> None:
         """Init variables."""
-        self.site_data = kwargs["site_data"]
+        super().__init__(browser, **kwargs)
         self.base_url = kwargs["site_data"]["url"]
-        self.url = kwargs["url"]
         self.viewport_size = kwargs["viewport_size"]
-        self.browser = browser
-        self.audit_id = kwargs["audit_id"]
-        self.page_id = kwargs["page_id"]
         self.best_practice = config.audit_plugins["axe_core_audit"]["best-practice"]
 
     def best_practice_string(self, best_practice: bool) -> str:
@@ -150,14 +144,7 @@ class AxeCoreAudit:
             return False
 
         # Get page information from DefaultAudit
-        default_audit = DefaultAudit(
-            browser=self.browser,
-            url=self.url,
-            site_data=self.site_data,
-            audit_id=self.audit_id,
-            page_id=self.page_id,
-        )
-        default_audit_row = default_audit.run()[0]
+        default_audit_row = super().run()[0]
 
         expanded_results = self.run_generate_expanded_results(axe_core_results)
 

--- a/src/audit_plugins/axe_core_audit.py
+++ b/src/audit_plugins/axe_core_audit.py
@@ -123,7 +123,7 @@ class AxeCoreAudit(DefaultAudit):
 
         return expanded_results
 
-    def run(self) -> list[Any] | bool:
+    def run(self) -> list[dict[str, Any]] | bool:
         """Run an axe-core on a specified URL.
 
         Returns:

--- a/src/audit_plugins/default_audit.py
+++ b/src/audit_plugins/default_audit.py
@@ -35,12 +35,8 @@ class DefaultAudit:
         self.audit_id = kwargs["audit_id"]
         self.page_id = kwargs["page_id"]
 
-    def run(self) -> list[dict[Any, Any]]:
-        """Run the audit.
-
-        Returns:
-            list[dict[Any, Any]]: a list of audit result dicts
-        """
+    @property
+    def _default_audit_row(self) -> dict[str, Any]:
         # If we are not crawling pages for additional links, then
         # use the subdomain + domain as the base_url
         base_url = self.site_data["url"]
@@ -50,15 +46,21 @@ class DefaultAudit:
             parsed_url = urllib.parse.urlparse(base_url)
             base_url = parsed_url.scheme + "://" + parsed_url.netloc
 
-        return [
-            {
-                "organisation": self.site_data["organisation"],
-                "sector": self.site_data["sector"],
-                "page_title": self.browser.driver.title,
-                "base_url": base_url,
-                "url": self.url,
-                "viewport_size": self.browser.driver.get_window_size(),
-                "audit_id": self.audit_id,
-                "page_id": self.page_id,
-            }
-        ]
+        return {
+            "organisation": self.site_data["organisation"],
+            "sector": self.site_data["sector"],
+            "page_title": self.browser.driver.title,
+            "base_url": base_url,
+            "url": self.url,
+            "viewport_size": self.browser.driver.get_window_size(),
+            "audit_id": self.audit_id,
+            "page_id": self.page_id,
+        }
+
+    def run(self) -> list[dict[Any, Any]] | bool:
+        """Run the audit.
+
+        Returns:
+            list[dict[Any, Any]]: a list of audit result dicts
+        """
+        return [self._default_audit_row]

--- a/src/audit_plugins/default_audit.py
+++ b/src/audit_plugins/default_audit.py
@@ -14,7 +14,7 @@ from src.browser import Browser
 # Audit classes MUST implement:
 # def __init__(self, browser: Browser, **kwargs) -> None
 #   - accepts a browser, and kwargs
-# run(self) -> bool/list
+# run(self) -> list[dict[str, Any]] | bool
 #   - runs the actual audit
 #   - if audit is successful, returns a list of dictionaries
 #       which form CSV data rows
@@ -57,7 +57,7 @@ class DefaultAudit:
             "page_id": self.page_id,
         }
 
-    def run(self) -> list[dict[Any, Any]] | bool:
+    def run(self) -> list[dict[str, Any]] | bool:
         """Run the audit.
 
         Returns:

--- a/src/audit_plugins/element_audit.py
+++ b/src/audit_plugins/element_audit.py
@@ -31,7 +31,7 @@ class ElementAudit(DefaultAudit):
         self.base_url = kwargs["site_data"]["url"]
         self.viewport_size = kwargs["viewport_size"]
 
-    def run(self) -> list[Any] | bool:
+    def run(self) -> list[dict[str, Any]] | bool:
         """Run an element detection on a specified URL.
 
         Returns:

--- a/src/audit_plugins/element_audit.py
+++ b/src/audit_plugins/element_audit.py
@@ -64,7 +64,7 @@ class ElementAudit(DefaultAudit):
             found_elements.append(element_data)
 
         # Get page information from DefaultAudit
-        default_audit_row = super().run()[0]
+        default_audit_row = self._default_audit_row
 
         # Add default_test_row to all results
         final_output = []

--- a/src/audit_plugins/element_audit.py
+++ b/src/audit_plugins/element_audit.py
@@ -19,23 +19,17 @@ from src.browser import Browser
 # import selenium.common.exceptions as sel_exceptions
 
 
-class ElementAudit:
+class ElementAudit(DefaultAudit):
     """element audit."""
-
-    # pylint: disable=too-many-instance-attributes
 
     audit_type = "ElementAudit"
 
     def __init__(self, browser: Browser, **kwargs: Any) -> None:
         """Init variables."""
+        super().__init__(browser, **kwargs)
         self.target_element = config.audit_plugins["element_audit"]["target_element_css_selector"]
-        self.site_data = kwargs["site_data"]
         self.base_url = kwargs["site_data"]["url"]
-        self.url = kwargs["url"]
         self.viewport_size = kwargs["viewport_size"]
-        self.browser = browser
-        self.audit_id = kwargs["audit_id"]
-        self.page_id = kwargs["page_id"]
 
     def run(self) -> list[Any] | bool:
         """Run an element detection on a specified URL.
@@ -70,14 +64,7 @@ class ElementAudit:
             found_elements.append(element_data)
 
         # Get page information from DefaultAudit
-        default_audit = DefaultAudit(
-            browser=self.browser,
-            url=self.url,
-            site_data=self.site_data,
-            audit_id=self.audit_id,
-            page_id=self.page_id,
-        )
-        default_audit_row = default_audit.run()[0]
+        default_audit_row = super().run()[0]
 
         # Add default_test_row to all results
         final_output = []

--- a/src/audit_plugins/focus_indicator_audit.py
+++ b/src/audit_plugins/focus_indicator_audit.py
@@ -137,7 +137,7 @@ class FocusIndicatorAudit(DefaultAudit):
             logging.exception("Failed to find body element")
             return None
 
-    def run(self) -> list[dict[Any, Any]] | bool:
+    def run(self) -> list[dict[str, Any]] | bool:
         """Run the audit.
 
         Returns:

--- a/src/audit_plugins/focus_indicator_audit.py
+++ b/src/audit_plugins/focus_indicator_audit.py
@@ -146,7 +146,7 @@ class FocusIndicatorAudit(DefaultAudit):
         """
         # Get page information from DefaultAudit
         common_properties = {
-            **super().run()[0],
+            **self._default_audit_row,
             "audit_type": FocusIndicatorAudit.audit_type,
             "helpUrl": ("https://www.w3.org/WAI/WCAG22/" "Understanding/focus-visible.html"),
         }

--- a/src/audit_plugins/focus_indicator_audit.py
+++ b/src/audit_plugins/focus_indicator_audit.py
@@ -23,23 +23,17 @@ from src.audit_plugins.default_audit import DefaultAudit
 from src.browser import Browser
 
 
-class FocusIndicatorAudit:
+class FocusIndicatorAudit(DefaultAudit):
     """Focus indiactor audit."""
-
-    # pylint: disable=too-many-instance-attributes
 
     audit_type = "FocusIndicatorAudit"
 
     def __init__(self, browser: Browser, **kwargs: Any) -> None:
         """Init variables."""
+        super().__init__(browser, **kwargs)
         self.root_element_css_selector = config.audit_plugins["focus_indicator_audit"]["root_element_css_selector"]
         self.pre_num_tab_presses = config.audit_plugins["focus_indicator_audit"]["pre_tab_key_presses"]
         self.max_num_tab_presses = config.audit_plugins["focus_indicator_audit"]["max_tab_key_presses"]
-        self.browser = browser
-        self.url = kwargs["url"]
-        self.site_data = kwargs["site_data"]
-        self.audit_id = kwargs["audit_id"]
-        self.page_id = kwargs["page_id"]
 
     def wait_for_page_to_stop_animating(self) -> bool:
         """Wait for animations to finish on the page.
@@ -151,15 +145,8 @@ class FocusIndicatorAudit:
             list[dict[Any, Any]]: a list of audit result dicts
         """
         # Get page information from DefaultAudit
-        default_audit_row = DefaultAudit(
-            browser=self.browser,
-            url=self.url,
-            site_data=self.site_data,
-            audit_id=self.audit_id,
-            page_id=self.page_id,
-        ).run()[0]
-
-        result_template = {
+        common_properties = {
+            **super().run()[0],
             "audit_type": FocusIndicatorAudit.audit_type,
             "helpUrl": ("https://www.w3.org/WAI/WCAG22/" "Understanding/focus-visible.html"),
         }
@@ -183,8 +170,7 @@ class FocusIndicatorAudit:
         if not animation_result:
             return [
                 {
-                    **default_audit_row,
-                    **result_template,
+                    **common_properties,
                     "description": (
                         "Page never stopped animating. "
                         "FocusIndicatorAudit could not run as "
@@ -259,8 +245,7 @@ class FocusIndicatorAudit:
         if not result_list:
             return [
                 {
-                    **default_audit_row,
-                    **result_template,
+                    **common_properties,
                     "description": "All tab presses had a focus indicator",
                     "html": "",
                     "num_issues": 0,
@@ -272,8 +257,7 @@ class FocusIndicatorAudit:
         for result in result_list:
             final_results.append(
                 {
-                    **default_audit_row,
-                    **result_template,
+                    **common_properties,
                     "description": (f"Tab key press #{result['tab_press']}" f" did not show a focus indicator"),
                     "html": result["html"],
                     "num_issues": 1,

--- a/src/audit_plugins/language_audit.py
+++ b/src/audit_plugins/language_audit.py
@@ -19,7 +19,6 @@ from selenium.common import WebDriverException
 
 from config import config
 from src.audit_plugins.default_audit import DefaultAudit
-from src.browser import Browser
 
 # Download Natural Language Toolkit data
 nltk_dir = os.getcwd() + "/nltk_data/"
@@ -33,18 +32,10 @@ dictionary = cmudict.dict()
 RUN_SENTIMENT_ANALYSIS = config.audit_plugins["language_audit"]["run_sentiment_analysis"]
 
 
-class LanguageAudit:
+class LanguageAudit(DefaultAudit):
     """Language analysis for web pages."""
 
     audit_type = "LanguageAudit"
-
-    def __init__(self, browser: Browser, **kwargs: Any) -> None:
-        """Init variables."""
-        self.browser = browser
-        self.url = kwargs["url"]
-        self.audit_id = kwargs["audit_id"]
-        self.page_id = kwargs["page_id"]
-        self.site_data = kwargs["site_data"]
 
     def run(self) -> list[dict[Any, Any]] | bool:
         """Run the audit.
@@ -90,13 +81,7 @@ class LanguageAudit:
                 output_rows[0][key] = str(value)
 
         # Get page information from DefaultAudit
-        default_audit_row = DefaultAudit(
-            browser=self.browser,
-            url=self.url,
-            site_data=self.site_data,
-            audit_id=self.audit_id,
-            page_id=self.page_id,
-        ).run()[0]
+        default_audit_row = super().run()[0]
 
         output_rows = [{**default_audit_row, **row} for row in output_rows]
 

--- a/src/audit_plugins/language_audit.py
+++ b/src/audit_plugins/language_audit.py
@@ -80,10 +80,7 @@ class LanguageAudit(DefaultAudit):
             for key, value in sentiment.items():
                 output_rows[0][key] = str(value)
 
-        # Get page information from DefaultAudit
-        default_audit_row = super().run()[0]
-
-        output_rows = [{**default_audit_row, **row} for row in output_rows]
+        output_rows = [{**self._default_audit_row, **row} for row in output_rows]
 
         return output_rows
 

--- a/src/audit_plugins/language_audit.py
+++ b/src/audit_plugins/language_audit.py
@@ -37,7 +37,7 @@ class LanguageAudit(DefaultAudit):
 
     audit_type = "LanguageAudit"
 
-    def run(self) -> list[dict[Any, Any]] | bool:
+    def run(self) -> list[dict[str, Any]] | bool:
         """Run the audit.
 
         Returns:

--- a/src/audit_plugins/reflow_audit.py
+++ b/src/audit_plugins/reflow_audit.py
@@ -108,7 +108,7 @@ class ReflowAudit(DefaultAudit):
 
         return [
             {
-                **super().run()[0],
+                **self._default_audit_row,
                 "audit_type": ReflowAudit.audit_type,
                 "url": self.url,
                 "overflows": overflow_amount > 0,

--- a/src/audit_plugins/reflow_audit.py
+++ b/src/audit_plugins/reflow_audit.py
@@ -41,7 +41,7 @@ class ReflowAudit(DefaultAudit):
                 "To enable headless mode, set headless to true in config.json."
             )
 
-    def run(self) -> list[dict[Any, Any]] | bool:
+    def run(self) -> list[dict[str, Any]] | bool:
         """Run the test.
 
         WCAG 1.4.10 Reflow is partially tested by zooming

--- a/src/audit_plugins/screenshot_audit.py
+++ b/src/audit_plugins/screenshot_audit.py
@@ -74,7 +74,7 @@ class ScreenshotAudit(DefaultAudit):
 
         return [
             {
-                **super().run()[0],
+                **self._default_audit_row,
                 "audit_type": ScreenshotAudit.audit_type,
                 "screenshot": self.audit_id + ".png",
             }

--- a/src/audit_plugins/screenshot_audit.py
+++ b/src/audit_plugins/screenshot_audit.py
@@ -28,7 +28,7 @@ class ScreenshotAudit(DefaultAudit):
             cv2.IMREAD_COLOR,
         )
 
-    def run(self) -> list[dict[Any, Any]] | bool:
+    def run(self) -> list[dict[str, Any]] | bool:
         """Run the audit.
 
         Returns:

--- a/src/audit_plugins/screenshot_audit.py
+++ b/src/audit_plugins/screenshot_audit.py
@@ -10,21 +10,12 @@ import numpy as np
 
 from config import config
 from src.audit_plugins.default_audit import DefaultAudit
-from src.browser import Browser
 
 
-class ScreenshotAudit:
+class ScreenshotAudit(DefaultAudit):
     """Screenshot Audit."""
 
     audit_type = "ScreenshotAudit"
-
-    def __init__(self, browser: Browser, **kwargs: Any) -> None:
-        """Init variables."""
-        self.browser = browser
-        self.url = kwargs["url"]
-        self.site_data = kwargs["site_data"]
-        self.audit_id = kwargs["audit_id"]
-        self.page_id = kwargs["page_id"]
 
     def screenshot(self) -> Any:
         """Take a screenshot of the page that's loaded in the browser.
@@ -81,23 +72,10 @@ class ScreenshotAudit:
             logging.exception("Failed to save screenshot")
             return False
 
-        # Get page information from DefaultAudit
-        default_audit_row = DefaultAudit(
-            browser=self.browser,
-            url=self.url,
-            site_data=self.site_data,
-            audit_id=self.audit_id,
-            page_id=self.page_id,
-        ).run()[0]
-
-        output_row = [
+        return [
             {
-                **default_audit_row,
-                **{
-                    "audit_type": ScreenshotAudit.audit_type,
-                    "screenshot": self.audit_id + ".png",
-                },
+                **super().run()[0],
+                "audit_type": ScreenshotAudit.audit_type,
+                "screenshot": self.audit_id + ".png",
             }
         ]
-
-        return output_row


### PR DESCRIPTION
The design of the tool is such that audit plugins are required to conform to the same interface, and internally they invoke `DefaultAudit` so we might as well just make that their parent to let us remove some duplicate code (and in a couple of cases, entire constructors!), using a protected property to provide access to the default row since `run` is allowed to return a `bool` so it'd be more work to try using its return directly.

For now I've just focused on replacing what is already there, but I suspect there could be a property or two worth pulling into the parent constructor afterwards to let us remove further code