### PR TITLE
refactor: use pipe syntax instead of `Union`

### DIFF
--- a/src/audit_plugins/axe_core_audit.py
+++ b/src/audit_plugins/axe_core_audit.py
@@ -6,7 +6,7 @@ This plugin uses axe-core to test a webpage.
 import hashlib
 import logging
 import sys
-from typing import Any, Union
+from typing import Any
 
 import selenium
 
@@ -129,7 +129,7 @@ class AxeCoreAudit:
 
         return expanded_results
 
-    def run(self) -> Union[list[Any], bool]:
+    def run(self) -> list[Any] | bool:
         """Run an axe-core on a specified URL.
 
         Returns:

--- a/src/audit_plugins/element_audit.py
+++ b/src/audit_plugins/element_audit.py
@@ -6,7 +6,7 @@ can be customised in the config file using a CSS selector.
 """
 
 import logging
-from typing import Any, Union
+from typing import Any
 
 from bs4 import BeautifulSoup
 
@@ -37,7 +37,7 @@ class ElementAudit:
         self.audit_id = kwargs["audit_id"]
         self.page_id = kwargs["page_id"]
 
-    def run(self) -> Union[list[Any], bool]:
+    def run(self) -> list[Any] | bool:
         """Run an element detection on a specified URL.
 
         Returns:

--- a/src/audit_plugins/focus_indicator_audit.py
+++ b/src/audit_plugins/focus_indicator_audit.py
@@ -9,7 +9,7 @@ changed, then the focus indicator is invisible.
 import logging
 import sys
 import time
-from typing import Any, Union
+from typing import Any
 
 import cv2
 import numpy as np
@@ -121,7 +121,7 @@ class FocusIndicatorAudit:
             cv2.IMREAD_COLOR,
         )
 
-    def run(self) -> Union[list[dict[Any, Any]], bool]:
+    def run(self) -> list[dict[Any, Any]] | bool:
         """Run the audit.
 
         Returns:

--- a/src/audit_plugins/language_audit.py
+++ b/src/audit_plugins/language_audit.py
@@ -11,7 +11,7 @@ This file has 3 main functions:
 import logging
 import math
 import os
-from typing import Any, Union, cast
+from typing import Any, cast
 
 import nltk  # type: ignore
 from bs4 import BeautifulSoup
@@ -48,7 +48,7 @@ class LanguageAudit:
         self.page_id = kwargs["page_id"]
         self.site_data = kwargs["site_data"]
 
-    def run(self) -> Union[list[dict[Any, Any]], bool]:
+    def run(self) -> list[dict[Any, Any]] | bool:
         """Run the audit.
 
         Returns:

--- a/src/audit_plugins/reflow_audit.py
+++ b/src/audit_plugins/reflow_audit.py
@@ -17,7 +17,7 @@ Disclaimer:
 import logging
 import sys
 import time
-from typing import Any, Union
+from typing import Any
 
 from config import config
 from src.audit_plugins.default_audit import DefaultAudit
@@ -45,7 +45,7 @@ class ReflowAudit:
                 "To enable headless mode, set headless to true in config.json."
             )
 
-    def run(self) -> Union[list[dict[Any, Any]], bool]:
+    def run(self) -> list[dict[Any, Any]] | bool:
         """Run the test.
 
         WCAG 1.4.10 Reflow is partially tested by zooming

--- a/src/audit_plugins/screenshot_audit.py
+++ b/src/audit_plugins/screenshot_audit.py
@@ -3,7 +3,7 @@
 import contextlib
 import logging
 import os
-from typing import Any, Union
+from typing import Any
 
 import cv2
 import numpy as np
@@ -37,7 +37,7 @@ class ScreenshotAudit:
             cv2.IMREAD_COLOR,
         )
 
-    def run(self) -> Union[list[dict[Any, Any]], bool]:
+    def run(self) -> list[dict[Any, Any]] | bool:
         """Run the audit.
 
         Returns:

--- a/src/browser.py
+++ b/src/browser.py
@@ -7,7 +7,7 @@ import logging
 import platform
 import time
 import traceback
-from typing import Any, Union, cast
+from typing import Any, cast
 
 import selenium
 from selenium import webdriver
@@ -16,10 +16,7 @@ from selenium.webdriver.firefox.service import Service as FirefoxService
 
 from config import config
 
-WebDriverType = Union[
-    selenium.webdriver.firefox.webdriver.WebDriver,
-    selenium.webdriver.chrome.webdriver.WebDriver,
-]
+WebDriverType = selenium.webdriver.firefox.webdriver.WebDriver | selenium.webdriver.chrome.webdriver.WebDriver
 
 
 class Browser:


### PR DESCRIPTION
This syntax for unions was introduced in Python 3.10 (we're on 3.12) and is already in use around the codebase so we might as well update the remaining usages