### PR TITLE
refactor: avoid storing additional data on the `config` dict

### DIFF
--- a/config.py
+++ b/config.py
@@ -104,7 +104,7 @@ class Config:
         if not self.is_path_subdir(self.config["base_urls_nohead_path"], "./base_urls"):
             raise ValueError("base_urls_nohead_path must be within base_urls folder")
 
-        self.config["url_lookup"] = self.import_url_lookup_files()
+        self.url_lookup = self.import_url_lookup_files()
 
         # global variable to store robots.txt data
         # the Crawler queries this and populates it
@@ -219,12 +219,12 @@ class Config:
         parsed_url = parse.urlparse(url)
         domain = parsed_url.netloc.lower()
 
-        if domain not in self.config["url_lookup"]:
+        if domain not in self.url_lookup:
             logging.warning("Agency data missing for: %s", url)
             return {"organisation": "Unknown", "sector": "Unknown"}
         return {
-            "organisation": self.config["url_lookup"][domain]["organisation"],
-            "sector": self.config["url_lookup"][domain]["sector"],
+            "organisation": self.url_lookup[domain]["organisation"],
+            "sector": self.url_lookup[domain]["sector"],
         }
 
     def import_url_lookup_files(self) -> dict[str, dict[str, str]]:

--- a/config.py
+++ b/config.py
@@ -51,11 +51,6 @@ class Config:
     # Threading lock (shared amongst all threads)
     lock = threading.RLock()
 
-    # global variable to store robots.txt data
-    # the Crawler queries this and populates it
-    # if no entry is found for a website.
-    robots_txt_cache: dict[str, urllib.robotparser.RobotFileParser]
-
     def __init__(self) -> None:
         """Read config.json into self.config."""
         self.config = self.read_config()
@@ -109,7 +104,7 @@ class Config:
         # global variable to store robots.txt data
         # the Crawler queries this and populates it
         # if no entry is found for a website.
-        self.config["robots_txt_cache"] = {}
+        self.robots_txt_cache: dict[str, urllib.robotparser.RobotFileParser] = {}
 
     def __resolve_automatic_settings(self) -> None:
         """Resolve configuration settings which are set to 'auto'.

--- a/config.py
+++ b/config.py
@@ -176,15 +176,6 @@ class Config:
             self.unique_id += 1
             return str(self.unique_id)
 
-    def __setattr__(self, attr_name: str, attr_value: Any) -> None:
-        """Set a config value (not saved to disk).
-
-        Args:
-            attr_name (str): attribute name
-            attr_value (Any): attribute value
-        """
-        self.__dict__[attr_name] = attr_value
-
     def __getattr__(self, name: str) -> Any:
         """Get attribute from config dict.
 


### PR DESCRIPTION
There are different typechecking rules applied for attributes vs keys and there isn't a need to store properties in the `config` dict itself so we can simplify things a bit by just using direct attributes.

Note this still isn't the safest because apparently just having a `__getattr__` at all causes `mypy` to assume _any_ attribute access is valid, but it's slightly better than what we currently have 🤷 