### PR TITLE
feat: rename `filter_to_domains` to `filter_to_urls`

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ Field descriptions:
   - a list of strings that can be used to restrict a CWAC scan to particular organisations. The organisations are specified in CSVs within the `base_urls` folder
   - e.g. ["Ministry of Social Development", "Department of Internal Affairs"]
   - partial string matches are included, e.g. "Internal" would match "Department of Internal Affairs"
-- `filter_to_domains`
-  - a list of strings of specific URLs to limit CWAC to (these URLs *must* be specified within a CSV inside of `base_urls_visit_path`)
+- `filter_to_urls`
+  - a list of strings that can be used to restrict a CWAC scan to particular URLs. The URLs are specified in CSVs within the `base_urls` folder, and are only considered when parsing the CSVs
   - e.g. ["https://msd.govt.nz/", "https://dia.govt.nz"]
   - partial string matches are included e.g. "dia.govt" matches "https://dia.govt.nz"
 - `viewport_sizes`

--- a/config.py
+++ b/config.py
@@ -42,7 +42,7 @@ class Config:
     base_urls_visit_path: str
     base_urls_nohead_path: str
     filter_to_organisations: list[str]
-    filter_to_domains: list[str]
+    filter_to_urls: list[str]
     viewport_sizes: dict[str, dict[str, int]]
     audit_plugins: dict[str, dict[str, Any]]
     record_unexpected_response_codes: bool

--- a/config/config_default.json
+++ b/config/config_default.json
@@ -22,7 +22,7 @@
     "record_unexpected_response_codes": true,
     "force_open_details_elements": true,
     "filter_to_organisations": [],
-    "filter_to_domains": [],
+    "filter_to_urls": [],
     "viewport_sizes": {
         "small": {"width": 320, "height": 450},
         "medium": {"width": 1280, "height": 800}

--- a/cwac.py
+++ b/cwac.py
@@ -58,7 +58,7 @@ class CWAC:
         Checks if a URL/Organisation should be included
         in the audit according to config_default.json's
         filter_to_organisations and
-        filter_to_domains.
+        filter_to_urls.
 
         Args:
             row (SiteData): a row from a CSV
@@ -73,19 +73,19 @@ class CWAC:
                     found_org = True
                     break
 
-        found_domain = False
-        if config.filter_to_domains:
-            for domain in config.filter_to_domains:
-                if domain in row["url"]:
-                    found_domain = True
+        found_url = False
+        if config.filter_to_urls:
+            for url in config.filter_to_urls:
+                if url in row["url"]:
+                    found_url = True
                     break
 
-        if config.filter_to_organisations and config.filter_to_domains:
-            return not (found_org and found_domain)
+        if config.filter_to_organisations and config.filter_to_urls:
+            return not (found_org and found_url)
         if config.filter_to_organisations:
             return not found_org
-        if config.filter_to_domains:
-            return not found_domain
+        if config.filter_to_urls:
+            return not found_url
 
         return False
 

--- a/src/output.py
+++ b/src/output.py
@@ -134,7 +134,7 @@ def output_init_message() -> None:
     print_log(f"Thread count: {config.thread_count}")
     print_log(f"Browser: {config.browser}")
     print_log(f"Filter to orgs: {config.filter_to_organisations}")
-    print_log(f"Filter to domains: {config.filter_to_domains}")
+    print_log(f"Filter to urls: {config.filter_to_urls}")
     print_log(f"Max links per domain: {config.max_links_per_domain}")
     print_log(f"Chrome binary location: {config.chrome_binary_location}")
     print_log(f"Chrome driver location: {config.chrome_driver_location}")


### PR DESCRIPTION
The current name is a little misleading since you might assume this is used whenever a url is being worked on e.g. as a result of crawling, when really it's only used when importing the CSVs to filter rows out based on the `url` column.

Having the property match the name of the column should reduce the confusion a bit, even if it still doesn't make it completely clear that it only applies to the URLs in the CSV