### PR TITLE
feat: introduce the concept of "audit subject" and do all url importing in the config class

### DIFF
--- a/config.py
+++ b/config.py
@@ -10,8 +10,17 @@ import re
 import sys
 import threading
 import urllib.robotparser
-from typing import Any
+from typing import Any, TypedDict, cast
 from urllib import parse
+
+
+class AuditSubject(TypedDict):
+    """Holds data for a subject that should be audited."""
+
+    organisation: str
+    url: str
+    sector: str
+    supports_head: bool
 
 
 class Config:
@@ -99,12 +108,149 @@ class Config:
         if not self.is_path_subdir(self.base_urls_nohead_path, "./base_urls"):
             raise ValueError("base_urls_nohead_path must be within base_urls folder")
 
-        self.url_lookup = self.import_url_lookup_files()
+        self.audit_subjects: list[AuditSubject] = self.__import_audit_subjects()
+
+        self.url_lookup = self.__map_audit_subjects_by_domain()
 
         # global variable to store robots.txt data
         # the Crawler queries this and populates it
         # if no entry is found for a website.
         self.robots_txt_cache: dict[str, urllib.robotparser.RobotFileParser] = {}
+
+    def __normalize_url(self, url: str) -> str:
+        """Normalize a URL, making it lowercase and stripping out any extra whitespace.
+
+        Args:
+            url (str): URL to normalize
+
+        Returns:
+            str: normalize URL
+        """
+        parsed = parse.urlparse(url)
+        modified = parsed._replace(scheme=parsed.scheme.lower(), netloc=parsed.netloc.lower())
+        return parse.urlunparse(modified)
+
+    def __import_base_urls_without_head_support(self) -> set[str]:
+        """Import base urls that don't support HEAD requests.
+
+        Returns:
+            set[str]: a list of base urls that don't support HEAD requests
+        """
+        folder_path = self.base_urls_nohead_path
+        base_urls = set()
+
+        for filename in os.listdir(folder_path):
+            if filename.endswith(".csv"):
+                with open(
+                    os.path.join(folder_path, filename),
+                    encoding="utf-8-sig",
+                    newline="",
+                ) as file:
+                    reader = csv.reader(file)
+                    header = next(reader)
+                    for row in reader:
+                        dict_row = cast(dict[str, str], dict(zip(header, row)))
+
+                        # Strip whitespace from URL
+                        dict_row["url"] = dict_row["url"].strip()
+
+                        # Make the URL lowercase
+                        dict_row["url"] = self.__normalize_url(dict_row["url"])
+
+                        base_urls.add(dict_row["url"])
+        return base_urls
+
+    def __should_skip(self, subject: AuditSubject) -> bool:
+        """Check if an audit subject being imported should be skipped.
+
+        Checks if a URL/Organisation should be included
+        in the audit according to config_default.json's
+        filter_to_organisations and
+        filter_to_urls.
+
+        Args:
+            subject (AuditSubject): an audit subject parsed from a CSV
+
+        Returns:
+            bool: True if the subject should be skipped, False otherwise
+        """
+        found_org = False
+        if self.filter_to_organisations:
+            for org in self.filter_to_organisations:
+                if org in subject["organisation"]:
+                    found_org = True
+                    break
+
+        found_url = False
+        if self.filter_to_urls:
+            for url in self.filter_to_urls:
+                if url in subject["url"]:
+                    found_url = True
+                    break
+
+        if self.filter_to_organisations and self.filter_to_urls:
+            return not (found_org and found_url)
+        if self.filter_to_organisations:
+            return not found_org
+        if self.filter_to_urls:
+            return not found_url
+
+        return False
+
+    def __import_audit_subjects(self) -> list[AuditSubject]:
+        """Import"""
+
+        subjects: list[AuditSubject] = []
+
+        folder_path = self.base_urls_visit_path
+
+        headless_base_urls = self.__import_base_urls_without_head_support()
+
+        for filename in os.listdir(folder_path):
+            if filename.endswith(".csv"):
+                with open(
+                    os.path.join(folder_path, filename),
+                    encoding="utf-8-sig",
+                    newline="",
+                ) as file:
+                    reader = csv.reader(file)
+                    header = next(reader)
+                    for row in reader:
+                        if len(row) != 3:
+                            raise ValueError(
+                                "CSV files must have 3 columns",
+                                row,
+                                filename,
+                            )
+
+                        subject = cast(AuditSubject, dict(zip(header, row)))
+
+                        # Parse the URL to get just the domain
+                        parsed_url = parse.urlparse(subject["url"])
+
+                        if parsed_url.scheme == "":
+                            logging.error("URL missing protocol, skipping %s", subject["url"])
+                            continue
+
+                        # If only_allow_https is True, then only add
+                        # URLs that start with https://
+                        if self.only_allow_https and parsed_url.scheme != "https":
+                            logging.error(
+                                "only_allow_https is True, skipping %s",
+                                subject["url"],
+                            )
+                            continue
+
+                        if self.__should_skip(subject):
+                            continue
+
+                        subject["url"] = self.__normalize_url(subject["url"])
+
+                        subject["supports_head"] = subject["url"] not in headless_base_urls
+
+                        subjects.append(subject)
+
+        return subjects
 
     def __resolve_automatic_settings(self) -> None:
         """Resolve configuration settings which are set to 'auto'.
@@ -222,8 +368,8 @@ class Config:
             "sector": self.url_lookup[domain]["sector"],
         }
 
-    def import_url_lookup_files(self) -> dict[str, dict[str, str]]:
-        """Import all CSV files in base_urls_visit_path.
+    def __map_audit_subjects_by_domain(self) -> dict[str, dict[str, str]]:
+        """Build a dictionary mapping audit subject information to their domain.
 
         This data is primarily used for looking up the agency details
         given a URL by using the lookup_organisation() method.
@@ -235,50 +381,21 @@ class Config:
         """
         base_urls: dict[str, dict[str, str]] = {}
 
-        for filename in os.listdir(self.base_urls_visit_path):
-            if filename.endswith(".csv"):
-                with open(
-                    os.path.join(self.base_urls_visit_path, filename),
-                    encoding="utf-8-sig",
-                    newline="",
-                ) as file:
-                    reader = csv.reader(file)
-                    next(reader)
-                    for row in reader:
-                        if len(row) != 3:
-                            raise ValueError(
-                                "CSV files must have 3 columns",
-                                row,
-                                filename,
-                            )
+        for subject in self.audit_subjects:
+            # Parse the URL to get just the domain
+            parsed_url = parse.urlparse(subject["url"])
 
-                        # Parse the URL to get just the domain
-                        parsed_url = parse.urlparse(row[1])
+            # Cast to lowercase
+            domain = parsed_url.netloc.lower()
 
-                        # Protocol
-                        if parsed_url.scheme == "":
-                            logging.error("URL missing protocol, skipping %s", row[1])
-                            continue
+            # Strip whitespace
+            domain = domain.strip()
 
-                        # Cast to lowercase
-                        domain = parsed_url.netloc.lower()
-
-                        # Strip whitespace
-                        domain = domain.strip()
-
-                        # If only_allow_https is True, then only add
-                        # URLs that start with https://
-                        if self.only_allow_https and parsed_url.scheme != "https":
-                            logging.error(
-                                "only_allow_https is True, skipping %s",
-                                row[1],
-                            )
-                            continue
-
-                        base_urls[domain] = {
-                            "organisation": row[0],
-                            "sector": row[2],
-                        }
+            base_urls[domain] = {
+                "organisation": subject["organisation"],
+                "sector": subject["sector"],
+            }
+            pass
         return base_urls
 
     def is_path_subdir(self, path: str, parent_path: str) -> bool:

--- a/cwac.py
+++ b/cwac.py
@@ -202,6 +202,13 @@ class CWAC:
                     reader = csv.reader(file)
                     header = next(reader)
                     for row in reader:
+                        if len(row) != 3:
+                            raise ValueError(
+                                "CSV files must have 3 columns",
+                                row,
+                                filename,
+                            )
+
                         dict_row = cast(SiteData, dict(zip(header, row)))
                         if self.should_skip_row(dict_row):
                             continue

--- a/cwac.py
+++ b/cwac.py
@@ -5,13 +5,11 @@ Refer to the README for more information.
 """
 
 import concurrent.futures
-import csv
 import logging
-import os
 import random
 from queue import SimpleQueue
-from typing import cast
-from urllib.parse import urlparse, urlunparse
+from typing import Any
+from urllib.parse import urlparse
 
 import src.verify
 from config import config
@@ -51,56 +49,6 @@ class CWAC:
         for result in results:
             result.result()
         logging.info("All threads complete")
-
-    def should_skip_row(self, row: SiteData) -> bool:
-        """Check if a row being imported should be skipped.
-
-        Checks if a URL/Organisation should be included
-        in the audit according to config_default.json's
-        filter_to_organisations and
-        filter_to_urls.
-
-        Args:
-            row (SiteData): a row from a CSV
-
-        Returns:
-            bool: True if the row should be skipped, False otherwise
-        """
-        found_org = False
-        if config.filter_to_organisations:
-            for org in config.filter_to_organisations:
-                if org in row["organisation"]:
-                    found_org = True
-                    break
-
-        found_url = False
-        if config.filter_to_urls:
-            for url in config.filter_to_urls:
-                if url in row["url"]:
-                    found_url = True
-                    break
-
-        if config.filter_to_organisations and config.filter_to_urls:
-            return not (found_org and found_url)
-        if config.filter_to_organisations:
-            return not found_org
-        if config.filter_to_urls:
-            return not found_url
-
-        return False
-
-    def lowercase_url(self, url: str) -> str:
-        """Make URL protocl/netloc lowercase.
-
-        Args:
-            url (str): URL to make lowercase
-
-        Returns:
-            str: lowercase URL
-        """
-        parsed = urlparse(url)
-        modified = parsed._replace(scheme=parsed.scheme.lower(), netloc=parsed.netloc.lower())
-        return urlunparse(modified)
 
     def shuffle_queue(self, queue: SimpleQueue[SiteData]) -> None:
         """Shuffle a SimpleQueue.
@@ -147,88 +95,17 @@ class CWAC:
         if skipped_item is not None:
             queue.put(skipped_item)
 
-    def import_base_urls_without_head_support(self) -> set[str]:
-        """Import base urls that don't support HEAD requests.
+    def __queue_audit_subjects(self) -> SimpleQueue[Any]:
+        audit_queue: SimpleQueue[SiteData] = SimpleQueue()
 
-        Returns:
-            set[str]: a list of base urls that don't support HEAD requests
-        """
-        folder_path = config.base_urls_nohead_path
-        base_urls = set()
-
-        for filename in os.listdir(folder_path):
-            if filename.endswith(".csv"):
-                with open(
-                    os.path.join(folder_path, filename),
-                    encoding="utf-8-sig",
-                    newline="",
-                ) as file:
-                    reader = csv.reader(file)
-                    header = next(reader)
-                    for row in reader:
-                        dict_row = cast(dict[str, str], dict(zip(header, row)))
-
-                        # Strip whitespace from URL
-                        dict_row["url"] = dict_row["url"].strip()
-
-                        # Make the URL lowercase
-                        dict_row["url"] = self.lowercase_url(dict_row["url"])
-
-                        base_urls.add(dict_row["url"])
-        return base_urls
-
-    def import_base_urls(self) -> SimpleQueue[SiteData]:
-        """Import target URLs to visit and potentially crawl.
-
-        This function reads all CSVs in config.base_urls_visit_path
-        and returns a SimpleQueue of each row
-
-        Returns:
-            SimpleQueue: a SimpleQueue of URLs
-        """
-        folder_path = config.base_urls_visit_path
-
-        headless_base_urls = self.import_base_urls_without_head_support()
-
-        url_queue: SimpleQueue[SiteData] = SimpleQueue()
-
-        for filename in os.listdir(folder_path):
-            if filename.endswith(".csv"):
-                with open(
-                    os.path.join(folder_path, filename),
-                    encoding="utf-8-sig",
-                    newline="",
-                ) as file:
-                    reader = csv.reader(file)
-                    header = next(reader)
-                    for row in reader:
-                        if len(row) != 3:
-                            raise ValueError(
-                                "CSV files must have 3 columns",
-                                row,
-                                filename,
-                            )
-
-                        dict_row = cast(SiteData, dict(zip(header, row)))
-                        if self.should_skip_row(dict_row):
-                            continue
-
-                        # Strip whitespace from URL
-                        dict_row["url"] = dict_row["url"].strip()
-
-                        # Make the URL lowercase
-                        dict_row["url"] = self.lowercase_url(dict_row["url"])
-
-                        dict_row["supports_head"] = dict_row["url"] not in headless_base_urls
-
-                        CWAC.analytics.add_base_url(dict_row["url"])
-
-                        url_queue.put(dict_row)
+        for subject in config.audit_subjects:
+            audit_queue.put(subject)
+            CWAC.analytics.add_base_url(subject["url"])
 
         # If shuffle_queue is True, shuffle the queue
         if config.shuffle_base_urls:
-            self.shuffle_queue(url_queue)
-        return url_queue
+            self.shuffle_queue(audit_queue)
+        return audit_queue
 
     def __init__(self) -> None:
         """Set up CWAC and run the test.
@@ -241,7 +118,7 @@ class CWAC:
         output_init_message()
 
         # Import base_urls into global varaiable
-        CWAC.url_queue = self.import_base_urls()
+        CWAC.url_queue = self.__queue_audit_subjects()
 
         things_to_scan = "websites"
         if config.max_links_per_domain == 1:

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -12,7 +12,7 @@ import time
 import urllib
 import urllib.robotparser
 from queue import SimpleQueue
-from typing import Any, TypedDict
+from typing import Any
 
 import requests
 import selenium.common.exceptions

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -22,7 +22,7 @@ import src.audit_manager
 import src.audit_plugins
 import src.filters
 import src.output
-from config import config
+from config import AuditSubject, config
 from src.analytics import Analytics
 from src.audit_manager import AuditManager
 from src.browser import Browser
@@ -31,13 +31,7 @@ from src.output import CSVWriter
 # pylint: disable=too-many-branches, too-many-statements, too-many-locals
 
 
-class SiteData(TypedDict):
-    """Holds data for a site that should be crawled and audited."""
-
-    organisation: str
-    url: str
-    sector: str
-    supports_head: bool
+type SiteData = AuditSubject
 
 
 class Crawler:


### PR DESCRIPTION
Besides the general improvement of not importing the same set of files twice, this aims to make things generally easier to understand and maintain as right now we use "url" for a lot of things.

As part of this, a number of configuration options have changed:
  * `max_links_per_domain` -> `max_links_per_subject`
  * `shuffle_base_urls` -> `shuffle_audit_subjects`
  * `base_urls_visit_path` -> `audit_subjects_import_path`

This relates heavily to #145