### PR TITLE
feat: move off `config` global variable and class properties

### DIFF
--- a/config.py
+++ b/config.py
@@ -15,7 +15,7 @@ from urllib import parse
 
 
 class Config:
-    """A global config class used throughout CWAC.
+    """A config class used throughout CWAC.
 
     Config settings are stored in ./config/config_[xyz].json.
     """
@@ -51,9 +51,10 @@ class Config:
     # Threading lock (shared amongst all threads)
     lock = threading.RLock()
 
-    def __init__(self) -> None:
+    def __init__(self, config_filename: str) -> None:
         """Read config.json into self.config."""
-        self.config = self.read_config()
+        with open("./config/" + config_filename, "r", encoding="utf-8-sig") as file:
+            self.config = json.load(file)
 
         self.unique_id = 0
 
@@ -178,7 +179,7 @@ class Config:
             name (str): the name of the attribute (in config.json)
         """
         if name == "lock":
-            return config.lock
+            return self.config.lock
         return self.config[name]
 
     def read_config(self) -> Any:
@@ -301,6 +302,3 @@ class Config:
         # If the common path is the same as the parent path, then
         # path is a subdirectory of parent_path
         return common_path == parent_path
-
-
-config = Config()

--- a/src/audit_plugins/axe_core_audit.py
+++ b/src/audit_plugins/axe_core_audit.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import selenium
 
-from config import config
+from config import Config
 from src.audit_manager import AuditManager
 from src.audit_plugins.default_audit import DefaultAudit
 from src.browser import Browser
@@ -21,12 +21,12 @@ class AxeCoreAudit(DefaultAudit):
 
     audit_type = "AxeCoreAudit"
 
-    def __init__(self, browser: Browser, **kwargs: Any) -> None:
+    def __init__(self, config: Config, browser: Browser, **kwargs: Any) -> None:
         """Init variables."""
-        super().__init__(browser, **kwargs)
+        super().__init__(config, browser, **kwargs)
         self.base_url = kwargs["site_data"]["url"]
         self.viewport_size = kwargs["viewport_size"]
-        self.best_practice = config.audit_plugins["axe_core_audit"]["best-practice"]
+        self.best_practice = self.config.audit_plugins["axe_core_audit"]["best-practice"]
 
     def best_practice_string(self, best_practice: bool) -> str:
         """Return best practice string for reports."""

--- a/src/audit_plugins/default_audit.py
+++ b/src/audit_plugins/default_audit.py
@@ -6,7 +6,7 @@ This plugin returns basic page information.
 import urllib.parse
 from typing import Any
 
-from config import config
+from config import Config
 from src.browser import Browser
 
 # Audit classes for use with AuditManager
@@ -27,8 +27,9 @@ class DefaultAudit:
     It retrieves things such as the page title, viewport size, and base url.
     """
 
-    def __init__(self, browser: Browser, **kwargs: Any):
+    def __init__(self, config: Config, browser: Browser, **kwargs: Any):
         """Init variables."""
+        self.config = config
         self.browser = browser
         self.url = kwargs["url"]
         self.site_data = kwargs["site_data"]
@@ -40,7 +41,7 @@ class DefaultAudit:
         # If we are not crawling pages for additional links, then
         # use the subdomain + domain as the base_url
         base_url = self.site_data["url"]
-        if config.max_links_per_domain == 1:
+        if self.config.max_links_per_domain == 1:
             # Parse the url to get the subdomain and domain using urlparse
             # and then rejoin them to get the base_url
             parsed_url = urllib.parse.urlparse(base_url)

--- a/src/audit_plugins/element_audit.py
+++ b/src/audit_plugins/element_audit.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from bs4 import BeautifulSoup
 
-from config import config
+from config import Config
 
 # from src.audit_manager import AuditManager
 from src.audit_plugins.default_audit import DefaultAudit
@@ -24,10 +24,10 @@ class ElementAudit(DefaultAudit):
 
     audit_type = "ElementAudit"
 
-    def __init__(self, browser: Browser, **kwargs: Any) -> None:
+    def __init__(self, config: Config, browser: Browser, **kwargs: Any) -> None:
         """Init variables."""
-        super().__init__(browser, **kwargs)
-        self.target_element = config.audit_plugins["element_audit"]["target_element_css_selector"]
+        super().__init__(config, browser, **kwargs)
+        self.target_element = self.config.audit_plugins["element_audit"]["target_element_css_selector"]
         self.base_url = kwargs["site_data"]["url"]
         self.viewport_size = kwargs["viewport_size"]
 

--- a/src/audit_plugins/focus_indicator_audit.py
+++ b/src/audit_plugins/focus_indicator_audit.py
@@ -18,7 +18,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.remote.webelement import WebElement
 
-from config import config
+from config import Config
 from src.audit_plugins.default_audit import DefaultAudit
 from src.browser import Browser
 
@@ -28,12 +28,12 @@ class FocusIndicatorAudit(DefaultAudit):
 
     audit_type = "FocusIndicatorAudit"
 
-    def __init__(self, browser: Browser, **kwargs: Any) -> None:
+    def __init__(self, config: Config, browser: Browser, **kwargs: Any) -> None:
         """Init variables."""
-        super().__init__(browser, **kwargs)
-        self.root_element_css_selector = config.audit_plugins["focus_indicator_audit"]["root_element_css_selector"]
-        self.pre_num_tab_presses = config.audit_plugins["focus_indicator_audit"]["pre_tab_key_presses"]
-        self.max_num_tab_presses = config.audit_plugins["focus_indicator_audit"]["max_tab_key_presses"]
+        super().__init__(config, browser, **kwargs)
+        self.root_element_css_selector = self.config.audit_plugins["focus_indicator_audit"]["root_element_css_selector"]
+        self.pre_num_tab_presses = self.config.audit_plugins["focus_indicator_audit"]["pre_tab_key_presses"]
+        self.max_num_tab_presses = self.config.audit_plugins["focus_indicator_audit"]["max_tab_key_presses"]
 
     def wait_for_page_to_stop_animating(self) -> bool:
         """Wait for animations to finish on the page.
@@ -152,7 +152,7 @@ class FocusIndicatorAudit(DefaultAudit):
         }
 
         # If config.headless is False, log an error
-        if not config.headless:
+        if not self.config.headless:
             logging.error("ERROR: FocusIndicatorAudit needs headless=True in config.json")
             print("ERROR: FocusIndicatorAudit needs headless=True in config.json")
             sys.exit(1)

--- a/src/audit_plugins/language_audit.py
+++ b/src/audit_plugins/language_audit.py
@@ -17,7 +17,6 @@ from nltk.corpus import cmudict  # type: ignore
 from nltk.sentiment import SentimentIntensityAnalyzer  # type: ignore
 from selenium.common import WebDriverException
 
-from config import config
 from src.audit_plugins.default_audit import DefaultAudit
 
 # Download Natural Language Toolkit data
@@ -27,9 +26,6 @@ nltk.download("cmudict", download_dir=nltk_dir, quiet=True)
 nltk.download("vader_lexicon", download_dir=nltk_dir, quiet=True)
 nltk.data.path.append(nltk_dir)
 dictionary = cmudict.dict()
-
-# Bool to toggle if sentiment analysis is run
-RUN_SENTIMENT_ANALYSIS = config.audit_plugins["language_audit"]["run_sentiment_analysis"]
 
 
 class LanguageAudit(DefaultAudit):
@@ -75,7 +71,7 @@ class LanguageAudit(DefaultAudit):
         )
 
         # Perform sentiment analysis
-        if RUN_SENTIMENT_ANALYSIS:
+        if self.config.audit_plugins["language_audit"]["run_sentiment_analysis"]:
             sentiment = self.sentiment_analysis(content)
             for key, value in sentiment.items():
                 output_rows[0][key] = str(value)

--- a/src/audit_plugins/reflow_audit.py
+++ b/src/audit_plugins/reflow_audit.py
@@ -19,7 +19,7 @@ import sys
 import time
 from typing import Any
 
-from config import config
+from config import Config
 from src.audit_plugins.default_audit import DefaultAudit
 from src.browser import Browser
 
@@ -29,12 +29,12 @@ class ReflowAudit(DefaultAudit):
 
     audit_type = "ReflowAudit"
 
-    def __init__(self, browser: Browser, **kwargs: Any) -> None:
+    def __init__(self, config: Config, browser: Browser, **kwargs: Any) -> None:
         """Init variables."""
-        super().__init__(browser, **kwargs)
+        super().__init__(config, browser, **kwargs)
 
         # Provide warning if headless mode is not enabled
-        if not config.headless:
+        if not self.config.headless:
             logging.warning(
                 "Headless mode is not enabled."
                 "ReflowAudit performance will be reduced."
@@ -55,7 +55,7 @@ class ReflowAudit(DefaultAudit):
             bool: if the audit fails
             list[dict[Any, Any]]: a list of audit result dicts
         """
-        if not config.headless:
+        if not self.config.headless:
             # Log an error and quit
             logging.error("Headless mode must be enabled for ReflowAudit.")
             print("Headless mode must be enabled for ReflowAudit.")
@@ -83,11 +83,12 @@ class ReflowAudit(DefaultAudit):
             return False
 
         # Run a ScreenshotAudit if the page overflows
-        if config.audit_plugins["reflow_audit"]["screenshot_failures"] and overflow_amount > 0:
+        if self.config.audit_plugins["reflow_audit"]["screenshot_failures"] and overflow_amount > 0:
             # pylint: disable=import-outside-toplevel
             from src.audit_plugins.screenshot_audit import ScreenshotAudit
 
             screenshot_audit = ScreenshotAudit(
+                config=self.config,
                 browser=self.browser,
                 url=self.url,
                 site_data=self.site_data,

--- a/src/audit_plugins/screenshot_audit.py
+++ b/src/audit_plugins/screenshot_audit.py
@@ -8,7 +8,6 @@ from typing import Any
 import cv2
 import numpy as np
 
-from config import config
 from src.audit_plugins.default_audit import DefaultAudit
 
 
@@ -37,14 +36,14 @@ class ScreenshotAudit(DefaultAudit):
         """
         # create ./results/{config.audit_name}/screenshots folder
         # if it doesn't exist
-        if not os.path.exists("results/" + config.audit_name + "/screenshots"):
+        if not os.path.exists("results/" + self.config.audit_name + "/screenshots"):
             with contextlib.suppress(FileExistsError):
-                os.makedirs("results/" + config.audit_name + "/screenshots")
+                os.makedirs("results/" + self.config.audit_name + "/screenshots")
 
         # Take screenshot of the browser and save it as a PNG in /screenshots
         # With a unique filename
 
-        screenshot_path = "results/" + config.audit_name + "/screenshots/" + self.audit_id + ".png"
+        screenshot_path = "results/" + self.config.audit_name + "/screenshots/" + self.audit_id + ".png"
 
         # Get browser source code
         # source = self.browser.get_page_source()

--- a/src/output.py
+++ b/src/output.py
@@ -7,6 +7,8 @@ import threading
 import time
 from typing import Any
 
+from config import Config
+
 # pylint: disable=too-many-locals
 
 
@@ -98,9 +100,8 @@ class CSVWriter:
         return True
 
 
-def output_init_message() -> None:
+def output_init_message(config: Config) -> None:
     """Print the initial message to stdout and the log."""
-    from config import config  # pylint: disable=import-outside-toplevel
 
     def print_log(*message: str) -> None:
         """Print a message and write to the log file.
@@ -169,6 +170,7 @@ def generate_time_str_from_mins(mins: float) -> str:
 
 
 def print_progress_bar(
+    config: Config,
     iteration: int,
     total: int,
     start_time: float = 1,
@@ -176,12 +178,11 @@ def print_progress_bar(
     """Call in a loop to create terminal progress bar.
 
     Args:
+        config (Config): config object
         iteration (int): current iteration
         total (int): total iterations
         start_time (float): time the program started
     """
-    from config import config  # pylint: disable=import-outside-toplevel
-
     length: int = 20
     decimals: int = 1
 

--- a/src/verify.py
+++ b/src/verify.py
@@ -2,21 +2,20 @@
 
 import logging
 
-from config import config
 
-
-def verify_axe_results(pages_scanned: dict[str, set[str]]) -> None:
+def verify_axe_results(max_links_per_domain: int, pages_scanned: dict[str, set[str]]) -> None:
     """Perform a series of checks on the output test.
 
     Ensures output data is free of obvious errors.
 
     Args:
+        max_links_per_domain: number of max links expected per domain
         pages_scanned: dict of pages_scanned from Analytics
     """
     # Check that each site had the correct number of pages scanned
     # outputs non-conforming sites to the log
     for key, value in pages_scanned.items():
-        correct_len = config.max_links_per_domain
+        correct_len = max_links_per_domain
         if len(value) != correct_len:
             logging.warning(
                 "VERIFY: %s had %i pages scanned, not %i",


### PR DESCRIPTION
This makes it possible to (re)use CWAC programmatically and with different configurations by having the config passes around as an argument / property rather than sourcing it from a global variable; likewise I've also replaced CWAC's class properties with instance properties for the same reason, though we also need to do this for the analytics property anyway since it requires a copy of the loaded config.

For audit plugins this means their constructor must now accept a `Config` as the first argument which should get assigned to a `config` property - this is handled by the constructor of the default audit plugin