### PR TITLE
feat: disable screenshot_audit by default

### DIFF
--- a/config/config_default.json
+++ b/config/config_default.json
@@ -53,7 +53,7 @@
         },
         "screenshot_audit": {
             "class_name": "ScreenshotAudit",
-            "enabled": true
+            "enabled": false
         },
         "element_audit": {
             "class_name": "ElementAudit",


### PR DESCRIPTION
This prevents screenshots from being taken and saved for every page scanned without it being expressly requested by a change to the config file. 

Resolves #132 