### PR TITLE
feat: try waiting for shinyapps to have loaded before continuing

### DIFF
--- a/src/browser.py
+++ b/src/browser.py
@@ -9,14 +9,17 @@ import platform
 import time
 import traceback
 from typing import Any, cast
+from urllib import parse
 
 import selenium
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.chrome.webdriver import WebDriver as ChromeWebDriver
+from selenium.webdriver.common.by import By
 from selenium.webdriver.firefox.options import Options as FirefoxOptions
 from selenium.webdriver.firefox.service import Service as FirefoxService
 from selenium.webdriver.firefox.webdriver import WebDriver as FirefoxWebDriver
+from selenium.webdriver.remote.webelement import WebElement
 
 from config import Config
 
@@ -91,9 +94,29 @@ class Browser:
           logger.info('%i attempts failed to .get: %s', attempts + 1, url)
           return False
 
+    return self.__ensure_loaded()
+
+  def __ensure_loaded(self) -> bool:
+    """Ensure the page had been loaded."""
     # Delay to allow page to load more
     time.sleep(self.config.delay_after_page_load)
-    return True
+
+    if not (parse.urlparse(self.driver.current_url).hostname or '').endswith('.shinyapps.io'):
+      return True
+
+    logging.info('shinyapp.io detected, waiting for _router_ui to have elements...')
+    waited_time = 0
+    while waited_time < 10:
+      time.sleep(self.config.delay_after_page_load)
+      waited_time += self.config.delay_after_page_load
+
+      el = self.driver.find_element(By.ID, '_router_ui')
+      children = cast(list[WebElement], el.get_property('children'))
+      if len(children) > 0:
+        logging.info('shinyapp.io page finished loading with %d elements', len(children))
+        return True
+    logging.error('shinyapp.io did not seem to finish loading within 10 seconds')
+    return False
 
   def safe_restart(self) -> None:
     """Restart the webdriver."""


### PR DESCRIPTION
Shiny apps look to be a hybrid that relies on loading content with JavaScript after the initial load and they don't seem to be particularly fast so right now it's very common for us to end up auditing nothing unless you've manually set the page load time (which everyone tries to avoid because that means more waiting in general).

This attempts to have the browser wait for Shiny apps to finish loading before continuing by checking that the `_router_ui` element has children, which looks to be where Shiny apps load their content into

Resolves #136