### PR TITLE
fix: don't consider urls filtered out due to content type as having an unexpected response code

### DIFF
--- a/src/crawler.py
+++ b/src/crawler.py
@@ -333,35 +333,23 @@ class Crawler:
         viewport_size=self.browser.get_window_size(),
       )
 
-  def are_url_headers_acceptable(
-    self,
-    base_url: str,
-    parent_url: str,
-    url: str,
-    status_code: int,
-    headers: dict[str, str],
-  ) -> bool:
+  def are_url_headers_acceptable(self, base_url: str, parent_url: str, url_data: src.filters.UrlData) -> bool:
     """Check if the URL has acceptable headers.
 
     Args:
         base_url (str): base URL - homepage of website specified
         parent_url (str): parent URL of url
-        url (str): URL to check
-        status_code (int): status code of the url
-        headers (dict): the headers of the url
+        url_data (src.filters.UrlData): url data
 
     Returns:
         bool: True if URL has acceptable headers, else False
     """
-    if status_code is None:
-      status_code = -1
-
     ok_status_codes = [200, 301, 302, 307, 308]
-    if status_code not in ok_status_codes:
+    if url_data['status_code'] not in ok_status_codes:
       logger.info(
         'URL filtered out due to bad http status_code: %s %i',
-        url,
-        status_code,
+        url_data['final_url'],
+        url_data['status_code'],
       )
       # Write bad response codes with CSVWriter
       csv_writer = src.output.CSVWriter()
@@ -369,15 +357,15 @@ class Crawler:
         {
           'base_url': base_url,
           'parent_url': parent_url,
-          'url': url,
-          'status_code': status_code,
+          'url': url_data['final_url'],
+          'status_code': url_data['status_code'],
         }
       )
       if self.config.record_unexpected_response_codes:
         csv_writer.write_csv_file(f'./results/{self.config.audit_name}/unexpected_response_codes.csv')
 
       return False
-    return src.filters.url_filter_by_header_content_type(url, headers)
+    return src.filters.url_filter_by_header_content_type(url_data['final_url'], url_data['headers'])
 
   def fetch_robots_txt(self, robots_txt_url: str) -> str:
     """Fetches a robots.txt file from a domain.
@@ -537,15 +525,8 @@ class Crawler:
           url,
           supports_head_requests=site_data['supports_head'],
         )
-        url_status_code = url_data['status_code']
         url = url_data['final_url']
-        if not self.are_url_headers_acceptable(
-          base_url=base_url,
-          parent_url=parent_url,
-          url=url,
-          status_code=url_status_code,
-          headers=url_data['headers'],
-        ):
+        if not self.are_url_headers_acceptable(base_url=base_url, parent_url=parent_url, url_data=url_data):
           continue
 
       if not self.url_filter.run_url_filters(url):

--- a/src/filters.py
+++ b/src/filters.py
@@ -2,7 +2,7 @@
 
 import logging
 import urllib.parse
-from typing import Any, Callable
+from typing import Any, Callable, TypedDict
 
 import requests
 
@@ -195,7 +195,15 @@ def url_filter_by_header_content_type(url: str, headers: dict[Any, Any]) -> bool
   return True
 
 
-def process_url_headers(config: Config, url: str, supports_head_requests: bool = True) -> dict[Any, Any]:
+class UrlData(TypedDict):
+  """Data about a request made for a particular url."""
+
+  status_code: int
+  final_url: str
+  headers: dict[str, str]
+
+
+def process_url_headers(config: Config, url: str, supports_head_requests: bool = True) -> UrlData:
   """Process a URL by handling the headers.
 
   It does the following:
@@ -208,10 +216,10 @@ def process_url_headers(config: Config, url: str, supports_head_requests: bool =
       supports_head_requests (bool): whether the URL supports HEAD requests
 
   Returns:
-      dict[Any, Any]]: A dict of status_code, final_url, and headers from the final request
+      UrlData: A dict of status_code, final_url, and headers from the final request
   """
   timeout = (10, 10)
-  final_url = None
+  final_url = url
   method = 'head'
 
   if not supports_head_requests:


### PR DESCRIPTION
This moves our content type check to happen as part of checking the status code rather than as part of resolving the final url & co so that such filtering no longer gets incorrectly reported as having an unexpected response code.

Eventually we should probably consolidate these areas of code as I think having the logic split like it is now creates a weird contention as evident by the names (i.e. we're checking the headers of the headers..?), which this is a good first step towards

Resolves #165
Resolves #122