### PR TITLE
fix: normalize trailing slashes in URL comparison to handle redirects

### DIFF
--- a/src/crawler.py
+++ b/src/crawler.py
@@ -181,6 +181,11 @@ class Crawler:
     current_base_url = remove_file_from_path(current_base_url)
     current_url = remove_file_from_path(current_url)
 
+    # Normalize trailing slashes to handle redirect edge cases
+    # (e.g., base_url "example.com/path/" redirecting to "example.com/path")
+    current_base_url = current_base_url.rstrip('/')
+    current_url = current_url.rstrip('/')
+
     # If the current_url does not start with the current_base_url,
     # then the url should not be scanned as it is not within the
     # scope of the current_base_url
@@ -200,6 +205,7 @@ class Crawler:
     for base_url in self.analytics.base_urls:
       base_url = lowercase_protocol_and_domain(base_url)
       base_url = remove_file_from_path(base_url)
+      base_url = base_url.rstrip('/')
       if current_url.startswith(base_url) and len(base_url) > len(current_base_url):
         # If the current_url starts with a base_url that is longer
         # this means that the current_url is within the scope of


### PR DESCRIPTION
## Summary

Fixes #177 - CWAC returns 0 pages scanned when base_url with trailing slash redirects to URL without trailing slash.

## Problem

When base_url `https://info.health.nz/careers/` redirects to `https://info.health.nz/careers`, the URL filtering logic rejects all discovered links because the comparison fails:

```
current_url.startswith(current_base_url)
# "https://info.health.nz/careers".startswith("https://info.health.nz/careers/")
# Returns False
```

## Solution

Strip trailing slashes from both URLs before comparison in `url_filter_prevent_intersections()`:

```python
current_base_url = current_base_url.rstrip('/')
current_url = current_url.rstrip('/')
```

This ensures URLs that only differ by trailing slash are treated as equivalent during scope checking.

## Changes

- `src/crawler.py`: Added `.rstrip('/')` normalization after `remove_file_from_path()` in two places within `url_filter_prevent_intersections()`