### PR TITLE
fix: write `axe_core_audit_template_aware` directly to report directory

### DIFF
--- a/export_report_data.py
+++ b/export_report_data.py
@@ -347,7 +347,7 @@ class DataExporter:
 
     # Write the data to CSV file with original column order
     data_frame.to_csv(
-      self.input_path + '/axe_core_audit_template_aware.csv',
+      self.output_path + '/axe_core_audit_template_aware.csv',
       index=False,
       columns=list(original_column_order),
     )

--- a/export_report_data_config.json
+++ b/export_report_data_config.json
@@ -43,12 +43,6 @@
         {
             "enabled": true,
             "export_type": "raw_data",
-            "input_filename": "axe_core_audit_template_aware.csv",
-            "output_filename": "axe_core_audit_template_aware.csv"
-        },
-        {
-            "enabled": true,
-            "export_type": "raw_data",
             "input_filename": "focus_indicator_audit.csv",
             "output_filename": "focus_indicator_audit.csv"
         },


### PR DESCRIPTION
As far as I can tell, there isn't any reason we're writing this report to the results directory, and doing so requires us to have a dedicated `raw_data` export that in turn will cause this report to be re-sorted after #223 is landed