### PR TITLE
chore: remove unneeded types package for `requests`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 beautifulsoup4==4.14.3
 types-beautifulsoup4==4.12.0.20250516
 requests==2.34.1
-types-requests==2.33.0.20260503
 selenium==4.44.0
 lxml==6.1.0
 responses==0.26.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4==4.14.3
 types-beautifulsoup4==4.12.0.20250516
-requests==2.34.1
+requests==2.34.2
 selenium==4.44.0
 lxml==6.1.0
 responses==0.26.0


### PR DESCRIPTION
The latest versions of `requests` ships with their own types