### PR TITLE
fix: lock Node to v24 and `@puppeteer/browsers` to v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Get node_modules
-FROM --platform=linux/amd64 node:slim AS node_modules_builder
+FROM --platform=linux/amd64 node:24-slim AS node_modules_builder
 
 WORKDIR /usr/app/
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
   },
   "scripts": {
-    "postinstall": "npx @puppeteer/browsers install chrome@$npm_package_config_chromeVersion"
+    "postinstall": "npx @puppeteer/browsers@2 install chrome@$npm_package_config_chromeVersion"
   },
   "config": {
     "chromeVersion": "122.0.6261.39"


### PR DESCRIPTION
`@puppeteer/browsers` has a [corruption issue](https://github.com/puppeteer/puppeteer/issues/14957) on Node v26 which has been solved in v3 by switching to using native `unzip` - that version isn't actually out yet, but frankly we should be locking to exact versions anyway so as a part on that this locks us to Node v24 and `@puppeteer/browsers` v2.

[Apparently we will need to make sure `unzip` is installed, as that is not present in slim images](https://github.com/puppeteer/puppeteer/issues/14988#issuecomment-4448143780), so I'll make sure to deal with that when v3 is released