### PR TITLE
build: use Node v22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Get node_modules
-FROM --platform=linux/amd64 node:24-slim AS node_modules_builder
+FROM --platform=linux/amd64 node:22-slim AS node_modules_builder
 
 WORKDIR /usr/app/
 


### PR DESCRIPTION
For some reason Chrome crashes when using Node v24 which I suspect is due to a dependency being updated, which doesn't happen on Node v22.

While I'd prefer not to downgrade, I'd rather the tool works in the meantime while I figure out what exactly needs to change for Node v24+ to work