### PR TITLE
CWAC-201: create an audit for page titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If the paths cannot be determined automatically, you can pass them manually by:
    - for Linux x64, the `chrome_binary_location` could be: `./chrome/linux-114.0.5735.90/chrome-linux64/chrome`
 
 > [!NOTE]
-> 
+>
 > Pull requests improving the automatic detection to cover additional OSs and architectures are welcome
 
 #### Updating Chrome for Testing (optional)
@@ -163,7 +163,7 @@ Field descriptions:
   - a path to a folder that contains CSV files (as many as you like). The CSV files **must** have the headers: organisation,url,sector.
   - The entries in `base_urls_visit_path` are extremely important, as these files are used to associate URLs with other information like their organisation, and sector
 - `base_urls_nohead_path`
-  - Defines which URLs don't support HEAD requests 
+  - Defines which URLs don't support HEAD requests
   - a path to a folder that contains CSV files (as many as you like). The CSV files **must** have only one header: url.
   - In cases where a HEAD request would be made CWAC will instead make a GET request
 - `force_open_details_elements`
@@ -255,6 +255,7 @@ By default, CWAC has 6 plugins:
 - `FocusIndicatorAudit` - a plugin that presses the tab key and detects if pixels changed after pressing tab, which can be an indicative test for WCAG 2.4.7 Focus Visible.
 - `ScreenshotAudit` - a plugin that simply takes screenshots of each web page tested and saves it to a folder in the results directory.
 - `ElementAudit` - a plugin that reports all instances of elements that match a CSS selector.
+- `TitleAudit` - a plugin that captures page titles to allow checking for uniqueness.
 
 The code for each plugin is located in `/src/audit_plugins/`
 
@@ -278,6 +279,10 @@ The format of `audit_plugin` entries requires a snake case name as the key, and 
         "enabled": true,
         "viewport_to_test": "small",
         "screenshot_failures": false
+    },
+    "title_audit": {
+        "class_name": "TitleAudit",
+        "enabled": true
     },
     "screenshot_audit": {
         "class_name": "ScreenshotAudit",

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Use `pre-commit run --all-files` to run all pre-commit hooks.
 ## Audit plugin architecture
 CWAC is designed to be extensible with plugins. This enables CWAC to run multiple different types of audits against web pages.
 
-By default, CWAC has 6 plugins:
+By default, CWAC has 8 plugins:
 - `DefaultAudit` - a plugin that simply gets basic page information e.g. viewport size, page title. This audit plugin is never used directly, it is always imported by other plugins so they don't have to fetch basic page information.
 - `AxeCoreAudit` - a plugin that runs `axe-core` on the page
 - `LanguageAudit` - a plugin that estimates text readability using a Flesch-Kincaid and SMOG score. It can also perform sentiment analysis.

--- a/config/config_default.json
+++ b/config/config_default.json
@@ -44,6 +44,10 @@
             "viewport_to_test": "small",
             "screenshot_failures": false
         },
+        "title_audit": {
+            "class_name": "TitleAudit",
+            "enabled": true
+        },
         "focus_indicator_audit": {
             "class_name": "FocusIndicatorAudit",
             "enabled": false,

--- a/src/audit_plugins/title_audit.py
+++ b/src/audit_plugins/title_audit.py
@@ -1,0 +1,26 @@
+"""TitleAudit plugin.
+
+This plugin records the titles of each page that is visited,
+which can be used to verify all pages have a unique title.
+"""
+
+import logging
+from typing import Any
+
+from src.audit_plugins.default_audit import DefaultAudit
+
+logger = logging.getLogger('cwac')
+
+
+class TitleAudit(DefaultAudit):
+  """element audit."""
+
+  audit_type = 'TitleAudit'
+
+  def run(self) -> list[dict[str, Any]] | bool:
+    """Run a title audit on a specified URL.
+
+    Returns:
+        list[dict[str, Any]]: a list of audit result dicts
+    """
+    return [{**self._default_audit_row, 'title': self.browser.driver.title}]

--- a/src/audit_plugins/title_audit.py
+++ b/src/audit_plugins/title_audit.py
@@ -4,16 +4,13 @@ This plugin records the titles of each page that is visited,
 which can be used to verify all pages have a unique title.
 """
 
-import logging
 from typing import Any
 
 from src.audit_plugins.default_audit import DefaultAudit
 
-logger = logging.getLogger('cwac')
-
 
 class TitleAudit(DefaultAudit):
-  """element audit."""
+  """Title audit."""
 
   audit_type = 'TitleAudit'
 
@@ -23,4 +20,4 @@ class TitleAudit(DefaultAudit):
     Returns:
         list[dict[str, Any]]: a list of audit result dicts
     """
-    return [{**self._default_audit_row, 'title': self.browser.driver.title}]
+    return [self._default_audit_row]


### PR DESCRIPTION
This helps with ensuring sites pass https://www.w3.org/WAI/WCAG22/Understanding/page-titled.html by recording the title of every page CWAC visits in a dedicated CSV, which can then be easily checked in a spreadsheet type program for duplicate entries.

Note that this currently produces a row _per viewport site_ per page because we don't support plugins opting out of being checked at different viewpoints, similar to how we don't support plugins taking action at the end of a run (which is what we'd want to be able to actually check for duplicate titles as part of the tool) - both of these would be useful to have, but right now it should be trivial to account for in a spreadsheet program