### PR TITLE
CWAC-217: generate exports after scanning using inline configuration

### DIFF
--- a/config.py
+++ b/config.py
@@ -59,6 +59,8 @@ class Config:
   record_unexpected_response_codes: bool
   force_open_details_elements: bool
 
+  reporting: dict[str, Any] | None
+
   # Threading lock (shared amongst all threads)
   lock = threading.RLock()
 

--- a/config/config_default.json
+++ b/config/config_default.json
@@ -70,5 +70,67 @@
       "target_element_css_selector": "input:not([type='search'])",
       "enabled": false
     }
+  },
+  "reporting": {
+    "output_filename_prefix": "",
+    "export_formats": [
+      {
+        "enabled": true,
+        "export_type": "generate_axe_core_template_aware_file",
+        "input_filename": "axe_core_audit.csv",
+        "output_filename": "axe_core_audit_template_aware.csv"
+      },
+      {
+        "enabled": true,
+        "export_type": "axe_core_template_aware_leaderboard",
+        "input_filename": "axe_core_audit.csv",
+        "output_filename": "axe_core_audit_leaderboard.csv"
+      },
+      {
+        "enabled": true,
+        "export_type": "leaderboard",
+        "input_filename": "focus_indicator_audit.csv",
+        "output_filename": "focus_indicator_audit_leaderboard.csv",
+        "query": "SELECT organisation, base_url, SUM(num_issues) as num_issues FROM cwac_table GROUP BY base_url ORDER BY num_issues DESC"
+      },
+      {
+        "enabled": true,
+        "export_type": "leaderboard",
+        "input_filename": "reflow_audit.csv",
+        "output_filename": "reflow_audit_leaderboard.csv",
+        "query": "SELECT organisation, base_url, AVG(overflow_amount_px) AS overflow_amount_px FROM cwac_table GROUP BY base_url ORDER BY overflow_amount_px DESC;"
+      },
+      {
+        "enabled": true,
+        "export_type": "leaderboard",
+        "input_filename": "language_audit.csv",
+        "output_filename": "language_audit_leaderboard.csv",
+        "query": "SELECT organisation, base_url, AVG(smog_gl) AS smog_grade_level FROM cwac_table GROUP BY base_url ORDER BY smog_grade_level DESC"
+      },
+      {
+        "enabled": true,
+        "export_type": "raw_data",
+        "input_filename": "axe_core_audit.csv",
+        "output_filename": "axe_core_audit.csv"
+      },
+      {
+        "enabled": true,
+        "export_type": "raw_data",
+        "input_filename": "focus_indicator_audit.csv",
+        "output_filename": "focus_indicator_audit.csv"
+      },
+      {
+        "enabled": true,
+        "export_type": "raw_data",
+        "input_filename": "reflow_audit.csv",
+        "output_filename": "reflow_audit.csv"
+      },
+      {
+        "enabled": true,
+        "export_type": "raw_data",
+        "input_filename": "language_audit.csv",
+        "output_filename": "language_audit.csv"
+      }
+    ]
   }
 }

--- a/cwac.py
+++ b/cwac.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse
 
 import src.verify
 from config import Config
+from export_report_data import DataExporter
 from src.analytics import Analytics
 from src.browser import Browser
 from src.crawler import Crawler, SiteData
@@ -159,6 +160,10 @@ class CWAC:
     print('\r\nCWAC complete! Data can be found', 'in the ./results folder.')
 
     logger.info('CWAC complete!')
+
+    if self.config.config.get('reporting') is not None:
+      logger.info('Doing report generation')
+      DataExporter(self.config.audit_name, True)
 
 
 if __name__ == '__main__':

--- a/export_report_data.py
+++ b/export_report_data.py
@@ -271,9 +271,13 @@ class DataExporter:
     with open(filename, 'r', encoding='utf-8-sig') as file:
       config = cast(dict[str, Any], json.load(file))
 
-    if use_inline_config:
-      return cast(dict[str, Any], config.get('reporting'))
-    return config
+    if not use_inline_config:
+      return config
+
+    reporting = config.get('reporting')
+    if not isinstance(reporting, dict):
+      raise KeyError('config.json has non-object "reporting" key')
+    return reporting
 
   def template_aware_algorithm(self, input_df: pd.DataFrame, groupby_cols: list[str]) -> pd.DataFrame:
     """Template aware algorithm - finds template-level issues.

--- a/export_report_data.py
+++ b/export_report_data.py
@@ -18,39 +18,19 @@ import pandas as pd
 class DataExporter:
   """Outputs CSV data from ./results/ to ./reports/."""
 
-  def __init__(self) -> None:
+  def __init__(self, results_folder_name: str) -> None:
     """Init vars."""
     self.config = self.import_config_file()
 
-    input_results_folder_name = self.__determine_results_folder_name()
+    print(f'Processing ./results/{results_folder_name}')
 
-    self.results_path = './results/' + input_results_folder_name
+    self.results_path = './results/' + results_folder_name
 
     # ensure the results path actually exists
     if not os.path.exists(self.results_path):
       raise FileNotFoundError(f'Input path {self.results_path} does not exist.')
     self.output_prefix = self.config['output_filename_prefix']
     self.iterate_export_formats()
-
-  def __determine_results_folder_name(self) -> str:
-    if len(sys.argv) > 1:
-      return sys.argv[1]
-
-    # get all the directories in the results folder, sorted naturally in
-    # ascending order so that the latest results will be the last item
-    convert: Callable[[str], int | str] = lambda text: int(text) if text.isdigit() else text
-    existing_results = sorted(
-      [d for d in os.listdir('./results') if os.path.isdir(f'./results/{d}')],
-      key=lambda key: [convert(c) for c in re.split('([0-9]+)', key)],
-    )
-
-    if len(existing_results) == 0:
-      raise ValueError('could not determine latest results folder - have you run an audit?')
-    latest_result = existing_results[-1]
-
-    print(f'Processing ./results/{latest_result}')
-
-    return latest_result
 
   def __build_results_path(self, sub: str) -> str:
     if sub in ('', '.', '..') or '..' in sub or '/' in sub or '\\' in sub:
@@ -396,4 +376,22 @@ class DataExporter:
 
 
 if __name__ == '__main__':
-  exporter = DataExporter()
+
+  def resolve_results_folder_name() -> str:
+    """Resolve the results folder name when being invoked directly."""
+    if len(sys.argv) > 1:
+      return sys.argv[1]
+
+    # get all the directories in the results folder, sorted naturally in
+    # ascending order so that the latest results will be the last item
+    convert: Callable[[str], int | str] = lambda text: int(text) if text.isdigit() else text
+    existing_results = sorted(
+      [d for d in os.listdir('./results') if os.path.isdir(f'./results/{d}')],
+      key=lambda key: [convert(c) for c in re.split('([0-9]+)', key)],
+    )
+
+    if len(existing_results) == 0:
+      raise ValueError('could not determine latest results folder - have you run an audit?')
+    return existing_results[-1]
+
+  exporter = DataExporter(resolve_results_folder_name())

--- a/export_report_data.py
+++ b/export_report_data.py
@@ -18,10 +18,8 @@ import pandas as pd
 class DataExporter:
   """Outputs CSV data from ./results/ to ./reports/."""
 
-  def __init__(self, results_folder_name: str) -> None:
+  def __init__(self, results_folder_name: str, use_inline_config: bool) -> None:
     """Init vars."""
-    self.config = self.import_config_file()
-
     print(f'Processing ./results/{results_folder_name}')
 
     self.results_path = './results/' + results_folder_name
@@ -29,6 +27,8 @@ class DataExporter:
     # ensure the results path actually exists
     if not os.path.exists(self.results_path):
       raise FileNotFoundError(f'Input path {self.results_path} does not exist.')
+
+    self.config = self.import_config_file(use_inline_config)
     self.output_prefix = self.config['output_filename_prefix']
     self.iterate_export_formats()
 
@@ -258,10 +258,21 @@ class DataExporter:
     audit_df = pd.read_csv(self.__build_results_path(input_filename))
     return audit_df
 
-  def import_config_file(self) -> dict[str, Any]:
-    """Import export_report_data_config.json."""
-    with open('export_report_data_config.json', 'r', encoding='utf-8-sig') as file:
+  def import_config_file(self, use_inline_config: bool) -> dict[str, Any]:
+    """Import the configuration file.
+
+    If `use_inline_config` is true then the configuration will be imported from the
+    "reporting" configuration within the input results config.json.
+
+    Otherwise, the `export_report_data_config.json` file will be used.
+    """
+    filename = self.__build_results_path('config.json') if use_inline_config else 'export_report_data_config.json'
+
+    with open(filename, 'r', encoding='utf-8-sig') as file:
       config = cast(dict[str, Any], json.load(file))
+
+    if use_inline_config:
+      return cast(dict[str, Any], config.get('reporting'))
     return config
 
   def template_aware_algorithm(self, input_df: pd.DataFrame, groupby_cols: list[str]) -> pd.DataFrame:
@@ -394,4 +405,4 @@ if __name__ == '__main__':
       raise ValueError('could not determine latest results folder - have you run an audit?')
     return existing_results[-1]
 
-  exporter = DataExporter(resolve_results_folder_name())
+  exporter = DataExporter(resolve_results_folder_name(), False)


### PR DESCRIPTION
Currently report generation is a two step process which is a bit tedious when running in automated context so this modifies the data exporter class to:
  * take an input directory as an argument, moving the "infer latest results directory" into the top level
  * write the reports to a nested directory within the results if `output_within_results` is `true`
  * read the export configuration from a subsection of the `config.json` within the results

These changes make it possible for `CWAC` to call the exporter at the end of a scan while still using a single configuration file and output directory