### PR TITLE
feat: output reports into results

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ You can either use the raw data stored in teh `./results/` folder directly, or y
 
 The CWAC data exporter is in the file `export_report_data.py`, and its configuration is in `export_report_data_config.json`.
 
-To use the CWAC data exporter, run `python export_report_data.py` and it will generate various leaderboard CSVs etc for the latest audit results, placing the output in `./reports/` in a directory with the same name as the results.
+To use the CWAC data exporter, run `python export_report_data.py` and it will generate various leaderboard CSVs etc for the latest audit results, placing the output next to the raw results.
 
 You can also provide the name of a directory in the `./results` folder to generate the reports for older results.
 

--- a/export_report_data.py
+++ b/export_report_data.py
@@ -25,13 +25,10 @@ class DataExporter:
     input_results_folder_name = self.__determine_results_folder_name()
 
     self.input_path = './results/' + input_results_folder_name + '/'
-    self.output_path = './reports/' + input_results_folder_name + '/'
+    self.output_path = self.input_path
     # assert the input_path exists
     if not os.path.exists(self.input_path):
       raise FileNotFoundError(f'Input path {self.input_path} does not exist.')
-    # create ouptut folder if it doesn't exist
-    if not os.path.exists(self.output_path):
-      os.makedirs(self.output_path)
     self.output_prefix = self.output_path + self.config['output_filename_prefix']
     self.iterate_export_formats()
 

--- a/export_report_data_config.json
+++ b/export_report_data_config.json
@@ -33,30 +33,6 @@
       "input_filename": "language_audit.csv",
       "output_filename": "language_audit_leaderboard.csv",
       "query": "SELECT organisation, base_url, AVG(smog_gl) AS smog_grade_level FROM cwac_table GROUP BY base_url ORDER BY smog_grade_level DESC"
-    },
-    {
-      "enabled": true,
-      "export_type": "raw_data",
-      "input_filename": "axe_core_audit.csv",
-      "output_filename": "axe_core_audit.csv"
-    },
-    {
-      "enabled": true,
-      "export_type": "raw_data",
-      "input_filename": "focus_indicator_audit.csv",
-      "output_filename": "focus_indicator_audit.csv"
-    },
-    {
-      "enabled": true,
-      "export_type": "raw_data",
-      "input_filename": "reflow_audit.csv",
-      "output_filename": "reflow_audit.csv"
-    },
-    {
-      "enabled": true,
-      "export_type": "raw_data",
-      "input_filename": "language_audit.csv",
-      "output_filename": "language_audit.csv"
     }
   ]
 }


### PR DESCRIPTION
This makes things overall simpler by keeping everything about a scan in a single place - note in the context of the web application I believe `output_filename_prefix` can be used to break out of the directory, which I'll be looking into separately