### PR TITLE
fix: don't allow input and output paths to escape results directory when generating reports

### DIFF
--- a/export_report_data.py
+++ b/export_report_data.py
@@ -29,11 +29,7 @@ class DataExporter:
     # assert the input_path exists
     if not os.path.exists(self.input_path):
       raise FileNotFoundError(f'Input path {self.input_path} does not exist.')
-
-    # ensure that the output prefix itself is acceptable
-    self.output_prefix = self.output_path
-    self.output_prefix = self.__build_output_filename(self.config['output_filename_prefix'])
-
+    self.output_prefix = self.config['output_filename_prefix']
     self.iterate_export_formats()
 
   def __determine_results_folder_name(self) -> str:
@@ -56,11 +52,10 @@ class DataExporter:
 
     return latest_result
 
-  def __build_output_filename(self, path: str) -> str:
-    if path in ('', '.', '..') or '..' in path or '/' in path or '\\' in path:
+  def __build_path(self, base: str, sub: str) -> str:
+    if sub in ('', '.', '..') or '..' in sub or '/' in sub or '\\' in sub:
       raise ValueError(f'filename must be a simple path without path separators or consecutive dots')
-
-    return self.output_prefix + path
+    return os.path.join(base, sub)
 
   # noinspection PyDefaultArgument
   def sort_with_default(self, df: pd.DataFrame, columns: list[str]) -> pd.DataFrame:
@@ -205,13 +200,15 @@ class DataExporter:
       df = self.import_audit_csv_to_df(input_filename)
       df = self.sort_with_default(df, [])
 
-      df.to_csv(self.__build_output_filename(output_filename), index=False)
+      df.to_csv(self.__build_path(self.output_path, self.output_prefix + output_filename), index=False)
 
       return
 
     with (
       open(self.input_path + input_filename, 'r', encoding='utf-8-sig') as input_file,
-      open(self.__build_output_filename(output_filename), 'w', encoding='utf-8-sig') as output_file,
+      open(
+        self.__build_path(self.output_path, self.output_prefix + output_filename), 'w', encoding='utf-8-sig'
+      ) as output_file,
     ):
       output_file.write(input_file.read())
 
@@ -243,7 +240,7 @@ class DataExporter:
 
         # Write leaderboard to CSV
         output_df.to_csv(
-          self.__build_output_filename(export_format['output_filename']),
+          self.__build_path(self.output_path, self.output_prefix + export_format['output_filename']),
           index=False,
         )
 
@@ -272,7 +269,7 @@ class DataExporter:
 
         # Write the leaderboard to a CSV file
         leaderboard_df.to_csv(
-          self.__build_output_filename(export_format['output_filename']),
+          self.__build_path(self.output_path, self.output_prefix + export_format['output_filename']),
           index=False,
         )
 
@@ -364,7 +361,7 @@ class DataExporter:
 
     # Write the data to CSV file with original column order
     data_frame.to_csv(
-      self.__build_output_filename(output_filename),
+      self.__build_path(self.output_path, self.output_prefix + output_filename),
       index=False,
       columns=list(processed_column_order),
     )

--- a/export_report_data.py
+++ b/export_report_data.py
@@ -52,10 +52,10 @@ class DataExporter:
 
     return latest_result
 
-  def __build_path(self, base: str, sub: str) -> str:
+  def __build_results_path(self, sub: str) -> str:
     if sub in ('', '.', '..') or '..' in sub or '/' in sub or '\\' in sub:
       raise ValueError(f'filename must be a simple path without path separators or consecutive dots')
-    return os.path.join(base, sub)
+    return os.path.join(self.results_path, sub)
 
   # noinspection PyDefaultArgument
   def sort_with_default(self, df: pd.DataFrame, columns: list[str]) -> pd.DataFrame:
@@ -200,15 +200,13 @@ class DataExporter:
       df = self.import_audit_csv_to_df(input_filename)
       df = self.sort_with_default(df, [])
 
-      df.to_csv(self.__build_path(self.results_path, self.output_prefix + output_filename), index=False)
+      df.to_csv(self.__build_results_path(self.output_prefix + output_filename), index=False)
 
       return
 
     with (
-      open(self.__build_path(self.results_path, input_filename), 'r', encoding='utf-8-sig') as input_file,
-      open(
-        self.__build_path(self.results_path, self.output_prefix + output_filename), 'w', encoding='utf-8-sig'
-      ) as output_file,
+      open(self.__build_results_path(input_filename), 'r', encoding='utf-8-sig') as input_file,
+      open(self.__build_results_path(self.output_prefix + output_filename), 'w', encoding='utf-8-sig') as output_file,
     ):
       output_file.write(input_file.read())
 
@@ -227,9 +225,9 @@ class DataExporter:
 
       # Check if export_format["input_filename"] exists
       if 'input_filename' in export_format and not os.path.exists(
-        self.__build_path(self.results_path, export_format['input_filename'])
+        self.__build_results_path(export_format['input_filename'])
       ):
-        print(f'WARNING: File {self.__build_path(self.results_path, export_format["input_filename"])} does not exist.')
+        print(f'WARNING: File {self.__build_results_path(export_format["input_filename"])} does not exist.')
         continue
 
       if export_format['export_type'] == 'leaderboard':
@@ -242,7 +240,7 @@ class DataExporter:
 
         # Write leaderboard to CSV
         output_df.to_csv(
-          self.__build_path(self.results_path, self.output_prefix + export_format['output_filename']),
+          self.__build_results_path(self.output_prefix + export_format['output_filename']),
           index=False,
         )
 
@@ -271,13 +269,13 @@ class DataExporter:
 
         # Write the leaderboard to a CSV file
         leaderboard_df.to_csv(
-          self.__build_path(self.results_path, self.output_prefix + export_format['output_filename']),
+          self.__build_results_path(self.output_prefix + export_format['output_filename']),
           index=False,
         )
 
   def import_audit_csv_to_df(self, input_filename: str) -> pd.DataFrame:
     """Import the audit CSV file to a DataFrame."""
-    audit_df = pd.read_csv(self.__build_path(self.results_path, input_filename))
+    audit_df = pd.read_csv(self.__build_results_path(input_filename))
     return audit_df
 
   def import_config_file(self) -> dict[str, Any]:
@@ -340,7 +338,7 @@ class DataExporter:
         output_filename (str): The output filename.
     """
     # Read the CSV file into a list of dicts
-    file_path = self.__build_path(self.results_path, 'axe_core_audit.csv')
+    file_path = self.__build_results_path('axe_core_audit.csv')
 
     # If file doesn't exist, return
     if not os.path.exists(file_path):
@@ -363,7 +361,7 @@ class DataExporter:
 
     # Write the data to CSV file with original column order
     data_frame.to_csv(
-      self.__build_path(self.results_path, self.output_prefix + output_filename),
+      self.__build_results_path(self.output_prefix + output_filename),
       index=False,
       columns=list(processed_column_order),
     )

--- a/export_report_data.py
+++ b/export_report_data.py
@@ -57,8 +57,8 @@ class DataExporter:
     return latest_result
 
   def __build_output_filename(self, path: str) -> str:
-    if '/' in path or '\\' in path:
-      raise ValueError('filename must not contain path separators')
+    if path in ('', '.', '..') or '..' in path or '/' in path or '\\' in path:
+      raise ValueError(f'filename must be a simple path without path separators or consecutive dots')
 
     return self.output_prefix + path
 

--- a/export_report_data.py
+++ b/export_report_data.py
@@ -24,7 +24,7 @@ class DataExporter:
 
     input_results_folder_name = self.__determine_results_folder_name()
 
-    self.input_path = './results/' + input_results_folder_name + '/'
+    self.input_path = './results/' + input_results_folder_name
     self.output_path = self.input_path
     # assert the input_path exists
     if not os.path.exists(self.input_path):
@@ -205,7 +205,7 @@ class DataExporter:
       return
 
     with (
-      open(self.input_path + input_filename, 'r', encoding='utf-8-sig') as input_file,
+      open(self.__build_path(self.input_path, input_filename), 'r', encoding='utf-8-sig') as input_file,
       open(
         self.__build_path(self.output_path, self.output_prefix + output_filename), 'w', encoding='utf-8-sig'
       ) as output_file,
@@ -226,8 +226,10 @@ class DataExporter:
       print(f'Exporting {export_format["export_type"]} to {self.output_path}')
 
       # Check if export_format["input_filename"] exists
-      if 'input_filename' in export_format and not os.path.exists(self.input_path + export_format['input_filename']):
-        print(f'WARNING: File {self.input_path + export_format["input_filename"]} does not exist.')
+      if 'input_filename' in export_format and not os.path.exists(
+        self.__build_path(self.input_path, export_format['input_filename'])
+      ):
+        print(f'WARNING: File {self.__build_path(self.input_path, export_format["input_filename"])} does not exist.')
         continue
 
       if export_format['export_type'] == 'leaderboard':
@@ -275,7 +277,7 @@ class DataExporter:
 
   def import_audit_csv_to_df(self, input_filename: str) -> pd.DataFrame:
     """Import the audit CSV file to a DataFrame."""
-    audit_df = pd.read_csv(self.input_path + input_filename)
+    audit_df = pd.read_csv(self.__build_path(self.input_path, input_filename))
     return audit_df
 
   def import_config_file(self) -> dict[str, Any]:
@@ -338,7 +340,7 @@ class DataExporter:
         output_filename (str): The output filename.
     """
     # Read the CSV file into a list of dicts
-    file_path = self.input_path + '/axe_core_audit.csv'
+    file_path = self.__build_path(self.input_path, 'axe_core_audit.csv')
 
     # If file doesn't exist, return
     if not os.path.exists(file_path):

--- a/export_report_data.py
+++ b/export_report_data.py
@@ -24,11 +24,11 @@ class DataExporter:
 
     input_results_folder_name = self.__determine_results_folder_name()
 
-    self.input_path = './results/' + input_results_folder_name
-    self.output_path = self.input_path
-    # assert the input_path exists
-    if not os.path.exists(self.input_path):
-      raise FileNotFoundError(f'Input path {self.input_path} does not exist.')
+    self.results_path = './results/' + input_results_folder_name
+
+    # ensure the results path actually exists
+    if not os.path.exists(self.results_path):
+      raise FileNotFoundError(f'Input path {self.results_path} does not exist.')
     self.output_prefix = self.config['output_filename_prefix']
     self.iterate_export_formats()
 
@@ -200,14 +200,14 @@ class DataExporter:
       df = self.import_audit_csv_to_df(input_filename)
       df = self.sort_with_default(df, [])
 
-      df.to_csv(self.__build_path(self.output_path, self.output_prefix + output_filename), index=False)
+      df.to_csv(self.__build_path(self.results_path, self.output_prefix + output_filename), index=False)
 
       return
 
     with (
-      open(self.__build_path(self.input_path, input_filename), 'r', encoding='utf-8-sig') as input_file,
+      open(self.__build_path(self.results_path, input_filename), 'r', encoding='utf-8-sig') as input_file,
       open(
-        self.__build_path(self.output_path, self.output_prefix + output_filename), 'w', encoding='utf-8-sig'
+        self.__build_path(self.results_path, self.output_prefix + output_filename), 'w', encoding='utf-8-sig'
       ) as output_file,
     ):
       output_file.write(input_file.read())
@@ -223,13 +223,13 @@ class DataExporter:
         continue
 
       # print(f"Exporting {export_format['export_type']} to {export_format['output_filename']}")
-      print(f'Exporting {export_format["export_type"]} to {self.output_path}')
+      print(f'Exporting {export_format["export_type"]} to {self.results_path}')
 
       # Check if export_format["input_filename"] exists
       if 'input_filename' in export_format and not os.path.exists(
-        self.__build_path(self.input_path, export_format['input_filename'])
+        self.__build_path(self.results_path, export_format['input_filename'])
       ):
-        print(f'WARNING: File {self.__build_path(self.input_path, export_format["input_filename"])} does not exist.')
+        print(f'WARNING: File {self.__build_path(self.results_path, export_format["input_filename"])} does not exist.')
         continue
 
       if export_format['export_type'] == 'leaderboard':
@@ -242,7 +242,7 @@ class DataExporter:
 
         # Write leaderboard to CSV
         output_df.to_csv(
-          self.__build_path(self.output_path, self.output_prefix + export_format['output_filename']),
+          self.__build_path(self.results_path, self.output_prefix + export_format['output_filename']),
           index=False,
         )
 
@@ -271,13 +271,13 @@ class DataExporter:
 
         # Write the leaderboard to a CSV file
         leaderboard_df.to_csv(
-          self.__build_path(self.output_path, self.output_prefix + export_format['output_filename']),
+          self.__build_path(self.results_path, self.output_prefix + export_format['output_filename']),
           index=False,
         )
 
   def import_audit_csv_to_df(self, input_filename: str) -> pd.DataFrame:
     """Import the audit CSV file to a DataFrame."""
-    audit_df = pd.read_csv(self.__build_path(self.input_path, input_filename))
+    audit_df = pd.read_csv(self.__build_path(self.results_path, input_filename))
     return audit_df
 
   def import_config_file(self) -> dict[str, Any]:
@@ -340,7 +340,7 @@ class DataExporter:
         output_filename (str): The output filename.
     """
     # Read the CSV file into a list of dicts
-    file_path = self.__build_path(self.input_path, 'axe_core_audit.csv')
+    file_path = self.__build_path(self.results_path, 'axe_core_audit.csv')
 
     # If file doesn't exist, return
     if not os.path.exists(file_path):
@@ -363,7 +363,7 @@ class DataExporter:
 
     # Write the data to CSV file with original column order
     data_frame.to_csv(
-      self.__build_path(self.output_path, self.output_prefix + output_filename),
+      self.__build_path(self.results_path, self.output_prefix + output_filename),
       index=False,
       columns=list(processed_column_order),
     )

--- a/export_report_data.py
+++ b/export_report_data.py
@@ -29,7 +29,11 @@ class DataExporter:
     # assert the input_path exists
     if not os.path.exists(self.input_path):
       raise FileNotFoundError(f'Input path {self.input_path} does not exist.')
-    self.output_prefix = self.output_path + self.config['output_filename_prefix']
+
+    # ensure that the output prefix itself is acceptable
+    self.output_prefix = self.output_path
+    self.output_prefix = self.__build_output_filename(self.config['output_filename_prefix'])
+
     self.iterate_export_formats()
 
   def __determine_results_folder_name(self) -> str:
@@ -51,6 +55,12 @@ class DataExporter:
     print(f'Processing ./results/{latest_result}')
 
     return latest_result
+
+  def __build_output_filename(self, path: str) -> str:
+    if '/' in path or '\\' in path:
+      raise ValueError('filename must not contain path separators')
+
+    return self.output_prefix + path
 
   # noinspection PyDefaultArgument
   def sort_with_default(self, df: pd.DataFrame, columns: list[str]) -> pd.DataFrame:
@@ -195,13 +205,13 @@ class DataExporter:
       df = self.import_audit_csv_to_df(input_filename)
       df = self.sort_with_default(df, [])
 
-      df.to_csv(self.output_prefix + output_filename, index=False)
+      df.to_csv(self.__build_output_filename(output_filename), index=False)
 
       return
 
     with (
       open(self.input_path + input_filename, 'r', encoding='utf-8-sig') as input_file,
-      open(self.output_prefix + output_filename, 'w', encoding='utf-8-sig') as output_file,
+      open(self.__build_output_filename(output_filename), 'w', encoding='utf-8-sig') as output_file,
     ):
       output_file.write(input_file.read())
 
@@ -233,7 +243,7 @@ class DataExporter:
 
         # Write leaderboard to CSV
         output_df.to_csv(
-          self.output_prefix + export_format['output_filename'],
+          self.__build_output_filename(export_format['output_filename']),
           index=False,
         )
 
@@ -262,7 +272,7 @@ class DataExporter:
 
         # Write the leaderboard to a CSV file
         leaderboard_df.to_csv(
-          self.output_prefix + export_format['output_filename'],
+          self.__build_output_filename(export_format['output_filename']),
           index=False,
         )
 
@@ -354,7 +364,7 @@ class DataExporter:
 
     # Write the data to CSV file with original column order
     data_frame.to_csv(
-      self.output_prefix + output_filename,
+      self.__build_output_filename(output_filename),
       index=False,
       columns=list(processed_column_order),
     )

--- a/export_report_data.py
+++ b/export_report_data.py
@@ -54,7 +54,7 @@ class DataExporter:
 
   def __build_results_path(self, sub: str) -> str:
     if sub in ('', '.', '..') or '..' in sub or '/' in sub or '\\' in sub:
-      raise ValueError(f'filename must be a simple path without path separators or consecutive dots')
+      raise ValueError('filename must be a simple path without path separators or consecutive dots')
     return os.path.join(self.results_path, sub)
 
   # noinspection PyDefaultArgument


### PR DESCRIPTION
Currently it is possible to escape the results directory by using `../` in `output_filename_prefix`, `output_filename`, and `input_filename`.

This is not really a security risk but it's still not ideal so now we raise an error if a file path doesn't look nice including if it has a slash, consecutive dots, or is empty.

Technically it is still possible to escape using a symlink, but the tool does not use them itself nor does anything that would allow it to be tricked into creating one so it's not a concern