### PR TITLE
build: reduce the size of the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,14 +24,14 @@ RUN apt-get update && \
 # create cwac directory
 WORKDIR /cwac
 
-# copy in requirements.txt
-COPY requirements.txt .
-
 # create .venv
 RUN python3 -m venv .venv
 
 ENV VIRTUAL_ENV .venv
 ENV PATH .venv/bin:$PATH
+
+# copy in requirements.txt
+COPY requirements.txt .
 
 # pip install
 RUN python3 -m pip install --no-cache-dir -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN apt-get update && \
     python3-pip \
     python3.12-venv \
     libnss3-dev  && \
-    apt-get clean
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # create cwac directory
 WORKDIR /cwac

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,16 +14,12 @@ FROM --platform=linux/amd64 ubuntu:noble@sha256:723ad8033f109978f8c7e6421ee684ef
 # ubuntu equivalent (include upgrade)
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y wget && \
+    apt-get install -y wget python3-pip python3.12-venv libnss3-dev && \
     wget -nv https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
     apt-get install -y ./google-chrome-stable_current_amd64.deb && \
-    rm google-chrome-stable_current_amd64.deb && \
-    apt-get install -y \
-    python3-pip \
-    python3.12-venv \
-    libnss3-dev  && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives && \
+    rm google-chrome-stable_current_amd64.deb
 
 # create cwac directory
 WORKDIR /cwac

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=linux/amd64 ubuntu:noble@sha256:723ad8033f109978f8c7e6421ee684ef
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y wget && \
-    wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
+    wget -nv https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
     apt-get install -y ./google-chrome-stable_current_amd64.deb && \
     rm google-chrome-stable_current_amd64.deb && \
     apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ FROM --platform=linux/amd64 ubuntu:noble@sha256:723ad8033f109978f8c7e6421ee684ef
 # ubuntu equivalent (include upgrade)
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y wget python3-pip python3.12-venv libnss3-dev && \
+    apt-get install -y --no-install-recommends wget python3-pip python3.12-venv libnss3-dev && \
     wget -nv https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
-    apt-get install -y ./google-chrome-stable_current_amd64.deb && \
+    apt-get install -y --no-install-recommends ./google-chrome-stable_current_amd64.deb && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives && \
     rm google-chrome-stable_current_amd64.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,9 +59,9 @@ VOLUME /cwac/results
 ARG USER_ID=1000
 ARG GROUP_ID=1000
 
-RUN mkdir ./nltk_data/
-RUN chown -R $USER_ID:$GROUP_ID ./nltk_data/
-RUN chmod -R 700 ./nltk_data
+RUN mkdir ./nltk_data/ && \
+    chown -R $USER_ID:$GROUP_ID ./nltk_data/ && \
+    chmod -R 700 ./nltk_data
 
 # Change to non-root user
 USER $USER_ID:$GROUP_ID


### PR DESCRIPTION
This looks to shave about 100mb off the final image by
  * merging a couple of layers
  * removing both apt lists and archives
  * making `wget` quiet, since otherwise it'll write progress to a log file which can get big for large downloads
  * not installing recommended packages