### PR TITLE
chore: start using `ruff` for linting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,6 @@ updates:
           - bandit
           - flake8
           - flake8-simplify
-          - isort
           - mypy
           - pre-commit
           - pylint
@@ -28,7 +27,6 @@ updates:
           - bandit
           - flake8
           - flake8-simplify
-          - isort
           - mypy
           - pre-commit
           - pylint

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,6 @@ updates:
           - mypy
           - pre-commit
           - pylint
-          - pydocstyle
           - ruff
         update-types:
           - minor
@@ -30,7 +29,6 @@ updates:
           - mypy
           - pre-commit
           - pylint
-          - pydocstyle
           - ruff
         update-types:
           - minor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,11 +81,11 @@ jobs:
           persist-credentials: false
       - uses: astral-sh/ruff-action@v3 # v3.5.1
         with:
-          version-file: 'pyproject.toml'
+          version-file: requirements.txt
           args: 'check'
       - uses: astral-sh/ruff-action@v3 # v3.5.1
         with:
-          version-file: 'pyproject.toml'
+          version-file: requirements.txt
           args: 'format --check --diff'
   schemas:
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,20 +56,6 @@ jobs:
           python-version: '3.12'
       - run: pip install -r requirements.txt
       - run: mypy .
-  pydocstyle:
-    permissions:
-      contents: read # to fetch (actions/checkout)
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      - run: pip install -r requirements.txt
-      - run: pydocstyle --convention=google
   pylint:
     permissions:
       contents: read # to fetch (actions/checkout)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,19 +42,6 @@ jobs:
           python-version: '3.12'
       - run: pip install -r requirements.txt
       - run: flake8 --max-line-length 120 .
-  isort:
-    permissions:
-      contents: read # to fetch (actions/checkout)
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - uses: isort/isort-action@v1
-        with:
-          requirements-files: "requirements.txt"
-          configuration: "--check-only --diff --profile black"
   mypy:
     permissions:
       contents: read # to fetch (actions/checkout)
@@ -106,6 +93,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: astral-sh/ruff-action@v3 # v3.5.1
+        with:
+          version-file: 'pyproject.toml'
+          args: 'check'
       - uses: astral-sh/ruff-action@v3 # v3.5.1
         with:
           version-file: 'pyproject.toml'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,22 +2,11 @@ default_stages: [pre-commit, pre-push]
 default_language_version:
   python: python3.13
 repos:
-  - repo: https://github.com/astral-sh/ruff
-    rev: 0.14.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.21
     hooks:
-    - id: ruff
-      args: [
-        check
-      ]
-      types: ['python']
-  - repo: https://github.com/astral-sh/ruff
-    rev: 0.14.0
-    hooks:
-    - id: ruff
-      args: [
-        format
-      ]
-      types: ['python']
+      - id: ruff-check
+      - id: ruff-format
   - repo: https://github.com/PyCQA/flake8
     rev: 7.1.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,14 +35,6 @@ repos:
           language: system
           types: [python]
           args: ["-rn", "-sn"]
-  - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.3.0
-    hooks:
-      - id: pydocstyle
-        name: pydocstyle --convention=google
-        args: [
-          --convention=google
-        ]
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.10
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,11 +2,14 @@ default_stages: [pre-commit, pre-push]
 default_language_version:
   python: python3.13
 repos:
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+  - repo: https://github.com/astral-sh/ruff
+    rev: 0.14.0
     hooks:
-      - id: isort
-        args: ["--profile black", "."]
+    - id: ruff
+      args: [
+        check
+      ]
+      types: ['python']
   - repo: https://github.com/astral-sh/ruff
     rev: 0.14.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -225,7 +225,6 @@ The raw test results are stored within the `./results/` folder.
 CWAC uses several tools to maintain the quality and integrity of its source code, including:
 - [ruff](https://github.com/astral-sh/ruff), an uncompromising code formatter
 - [pydocstyle](https://github.com/PyCQA/pydocstyle), for linting docstrings
-- [isort](https://github.com/pycqa/isort), for sorting import statements
 - [bandit](https://github.com/PyCQA/bandit), for detecting potential security vulnerabilities
 - [flake8](https://github.com/pycqa/flake8), for linting
 - [pylint](https://github.com/PyCQA/pylint), for linting

--- a/README.md
+++ b/README.md
@@ -224,7 +224,6 @@ The raw test results are stored within the `./results/` folder.
 
 CWAC uses several tools to maintain the quality and integrity of its source code, including:
 - [ruff](https://github.com/astral-sh/ruff), an uncompromising code formatter
-- [pydocstyle](https://github.com/PyCQA/pydocstyle), for linting docstrings
 - [bandit](https://github.com/PyCQA/bandit), for detecting potential security vulnerabilities
 - [flake8](https://github.com/pycqa/flake8), for linting
 - [pylint](https://github.com/PyCQA/pylint), for linting

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ The raw test results are stored within the `./results/` folder.
 ## Checking CWAC's source code
 
 CWAC uses several tools to maintain the quality and integrity of its source code, including:
-- [ruff](https://github.com/astral-sh/ruff), an uncompromising code formatter
+- [ruff](https://github.com/astral-sh/ruff), an uncompromising code formatter and linter
 - [bandit](https://github.com/PyCQA/bandit), for detecting potential security vulnerabilities
 - [flake8](https://github.com/pycqa/flake8), for linting
 - [pylint](https://github.com/PyCQA/pylint), for linting

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ mypy==2.1.0
 pylint==4.0.6
 flake8==7.3.0
 flake8-simplify==0.30.0
-pydocstyle==6.3.0
 opencv-python==4.13.0.92
 numpy==2.5.0
 pandas==3.0.3

--- a/ruff.toml
+++ b/ruff.toml
@@ -5,6 +5,13 @@ line-length = 120
 quote-style = 'single'
 
 [lint]
-select = [
-  'I' # isort
+ignore = [
+  'D417' # don't require documentation for every function parameter
 ]
+select = [
+  'D', # pydocstyle
+  'I'  # isort
+]
+
+[lint.pydocstyle]
+convention = 'google'

--- a/ruff.toml
+++ b/ruff.toml
@@ -9,6 +9,7 @@ ignore = [
   'D417' # don't require documentation for every function parameter
 ]
 select = [
+  'F', # Pyflakes
   'D', # pydocstyle
   'I'  # isort
 ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -3,3 +3,8 @@ line-length = 120
 
 [format]
 quote-style = 'single'
+
+[lint]
+select = [
+  'I' # isort
+]

--- a/ruff.toml
+++ b/ruff.toml
@@ -15,8 +15,14 @@ select = [
   'F',    # Pyflakes
   'D',    # pydocstyle
   'SIM',  # flake8-simplify
-  'I'     # isort
+  'I',    # isort
+  'S'     # flake8-bandit
 ]
 
 [lint.pydocstyle]
 convention = 'google'
+
+[lint.per-file-ignores]
+"tests/**/*.py" = [
+  "S101" # allow using assert in tests
+]

--- a/ruff.toml
+++ b/ruff.toml
@@ -6,8 +6,9 @@ quote-style = 'single'
 
 [lint]
 ignore = [
-  'E501', # don't check line length (mainly for comments)
-  'D417'  # don't require documentation for every function parameter
+  'E501',    # don't check line length (mainly for comments)
+  'D417',    # don't require documentation for every function parameter
+  'PLR2004'  # most numbers are not magic
 ]
 select = [
   'E',    # pycodestyle
@@ -19,6 +20,7 @@ select = [
   'S',    # flake8-bandit
   'PLC',  # pylint conventions
   'PLE',  # pylint errors
+  'PLR',  # pylint refactors
   'PLW'   # pylint warnings
 ]
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -10,11 +10,12 @@ ignore = [
   'D417'  # don't require documentation for every function parameter
 ]
 select = [
-  'E', # pycodestyle
-  'W', # pycodestyle
-  'F', # Pyflakes
-  'D', # pydocstyle
-  'I'  # isort
+  'E',    # pycodestyle
+  'W',    # pycodestyle
+  'F',    # Pyflakes
+  'D',    # pydocstyle
+  'SIM',  # flake8-simplify
+  'I'     # isort
 ]
 
 [lint.pydocstyle]

--- a/ruff.toml
+++ b/ruff.toml
@@ -17,7 +17,8 @@ select = [
   'SIM',  # flake8-simplify
   'I',    # isort
   'S',    # flake8-bandit
-  'PLC'   # pylint conventions
+  'PLC',  # pylint conventions
+  'PLE'   # pylint errors
 ]
 
 [lint.pydocstyle]

--- a/ruff.toml
+++ b/ruff.toml
@@ -18,7 +18,8 @@ select = [
   'I',    # isort
   'S',    # flake8-bandit
   'PLC',  # pylint conventions
-  'PLE'   # pylint errors
+  'PLE',  # pylint errors
+  'PLW'   # pylint warnings
 ]
 
 [lint.pydocstyle]

--- a/ruff.toml
+++ b/ruff.toml
@@ -6,9 +6,12 @@ quote-style = 'single'
 
 [lint]
 ignore = [
-  'D417' # don't require documentation for every function parameter
+  'E501', # don't check line length (mainly for comments)
+  'D417'  # don't require documentation for every function parameter
 ]
 select = [
+  'E', # pycodestyle
+  'W', # pycodestyle
   'F', # Pyflakes
   'D', # pydocstyle
   'I'  # isort

--- a/ruff.toml
+++ b/ruff.toml
@@ -16,7 +16,8 @@ select = [
   'D',    # pydocstyle
   'SIM',  # flake8-simplify
   'I',    # isort
-  'S'     # flake8-bandit
+  'S',    # flake8-bandit
+  'PLC'   # pylint conventions
 ]
 
 [lint.pydocstyle]

--- a/src/audit_manager.py
+++ b/src/audit_manager.py
@@ -178,7 +178,7 @@ class AuditManager:
           logger.warning("Could not open <details> element titled '%s'", detail.text)
           continue
 
-  def run_audits(self) -> bool:
+  def run_audits(self) -> bool:  # noqa: PLR0912, PLR0915
     """Iterate through registered audits and runs them.
 
     Returns:

--- a/src/audit_plugins/language_audit.py
+++ b/src/audit_plugins/language_audit.py
@@ -248,7 +248,7 @@ class LanguageAudit(DefaultAudit):
       return True
 
     # If there are less than 200 words, the test is not applicable
-    if len(words) < 200:
+    if len(words) < 200:  # noqa: SIM103
       return True
 
     return False

--- a/src/audit_plugins/reflow_audit.py
+++ b/src/audit_plugins/reflow_audit.py
@@ -87,7 +87,7 @@ class ReflowAudit(DefaultAudit):
     # Run a ScreenshotAudit if the page overflows
     if self.config.audit_plugins['reflow_audit']['screenshot_failures'] and overflow_amount > 0:
       # pylint: disable=import-outside-toplevel
-      from src.audit_plugins.screenshot_audit import ScreenshotAudit
+      from src.audit_plugins.screenshot_audit import ScreenshotAudit  # noqa: PLC0415
 
       screenshot_audit = ScreenshotAudit(
         config=self.config,

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -199,7 +199,7 @@ class Crawler:
     # base_url
 
     for base_url in self.analytics.base_urls:
-      base_url = normalize_url(base_url)
+      base_url = normalize_url(base_url)  # noqa: PLW2901
       if current_url.startswith(base_url) and len(base_url) > len(current_base_url):
         # If the current_url starts with a base_url that is longer
         # this means that the current_url is within the scope of

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -650,8 +650,8 @@ class RandomQueue:
     # these random numbers are not used for security
     # or cryptographic purposes so it is safe to use
     # and 'nosec' is added to suppress bandit warning.
-    random_number = random.random()  # nosec
-    random_number *= random.random()  # nosec
+    random_number = random.random()  # nosec # noqa: S311
+    random_number *= random.random()  # nosec # noqa: S311
     return int(maximum * random_number)
 
   def clear(self) -> None:

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -455,7 +455,7 @@ class Crawler:
 
     return result
 
-  def crawl(self, site_data: SiteData, base_url: str) -> None:
+  def crawl(self, site_data: SiteData, base_url: str) -> None:  # noqa: PLR0912, PLR0915
     """Crawls a domain and executes the AuditManager.
 
     Loads a webpage, and runs a set of tests on that page. If

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,7 +58,7 @@ class TestChromeLocationsAutoResolution:
       ('Darwin', 'arm64', './chrome/mac_arm-123-abc/chrome-mac-arm64/', './drivers/chromedriver_mac_arm64'),
     ],
   )
-  def test_auto_resolves_for_supported_platforms(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+  def test_auto_resolves_for_supported_platforms(  # pylint: disable=too-many-arguments,too-many-positional-arguments  # noqa: PLR0913
     self,
     fs: FakeFilesystem,
     mocker: MockerFixture,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,7 +58,8 @@ class TestChromeLocationsAutoResolution:
       ('Darwin', 'arm64', './chrome/mac_arm-123-abc/chrome-mac-arm64/', './drivers/chromedriver_mac_arm64'),
     ],
   )
-  def test_auto_resolves_for_supported_platforms(  # pylint: disable=too-many-arguments,too-many-positional-arguments  # noqa: PLR0913
+  # pylint: disable-next=too-many-arguments,too-many-positional-arguments
+  def test_auto_resolves_for_supported_platforms(  # noqa: PLR0913
     self,
     fs: FakeFilesystem,
     mocker: MockerFixture,


### PR DESCRIPTION
Most of the tools that we're using to check the codebase can be replaced with `ruff` which we're already pulling in and is a lot faster, so this starts towards that.

For now `isort` and `pydocstyle` have been completely removed while other tools such as `bandit`, `flake8`, and `pylint` have been retained to help us verify the equivalent rules are being run by `ruff` since these don't have "drop-in replacement" configurations.

There are also additional rules that we probably should enable, but I've left those for a follow-up since they'll involve actual code changes