### PR TITLE
feat: change agency references from DIA to GDDA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,4 +33,4 @@ Please make sure to use `pre-commit` — it will automatically check your code m
 
 ## Questions?
 
-Feel free to contact the Web Standards team at the Department of Internal Affairs: web.standards@dia.govt.nz
+Feel free to contact the Web Standards team at the Government Digital Delivery Agency: web.standards@gdda.govt.nz

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![CWAC](/icons/logo.svg)
 
-CWAC is a project originally designed and developed by the Web Standards team within the Digital Public Service branch of <span lang="mi">Te Tari Taiwhenua</span> | Department of Internal Affairs, New Zealand Government.
+CWAC is designed and developed by the Web Standards team at <span lang="mi">Te Pūnaha Matihiko</span> | Government Digital Delivery Agency, New Zealand Government.
 
 **Note:** "CWAC" is pronounced "quack", like a duck.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@ Please don't file security-related issues in the Issues section of this reposito
 Checklist for reporting security issues:
 - Don’t disclose the issue publicly
 - Document the issue to help us understand how to fix it
-- Report the security issue to us directly via web.standards@dia.govt.nz
+- Report the security issue to us directly via web.standards@gdda.govt.nz
 - Be professional and clear in your communications
 - Wait to hear back from us
 - Provide any follow up information if requested to help resolve the issue

--- a/src/output.py
+++ b/src/output.py
@@ -120,7 +120,7 @@ def output_init_message(config: Config) -> None:
   print_log(
     '*' * 80,
     'Centralised Web Accessibility Checker (CWAC)',
-    'Te Tari Taiwhenua | Department of Internal Affairs',
+    'Te Pūnaha Matihiko | Government Digital Delivery Agency',
   )
   print_log(f'Run time: {time.strftime("%Y-%m-%d %H:%M:%S")}')
   print_log('*' * 80)


### PR DESCRIPTION
Updates references to DIA and web.standards@dia.govt.nz to GDDA and web.standards@gdda.govt.nz