### PR TITLE
CWAC-256: set up an end-to-end run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,4 +126,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: actions/setup-node@v4
+      - run: npm i
       - run: tests/e2e.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,3 +117,13 @@ jobs:
       - uses: actions/setup-node@v4
       - run: npm i
       - run: pytest .
+  e2e:
+    permissions:
+      contents: read # to fetch (actions/checkout)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - run: tests/e2e.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,5 +127,4 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions/setup-node@v4
-      - run: npm i
       - run: tests/e2e.sh

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -28,5 +28,5 @@ docker run --rm \
   --mount "type=bind,src=./config,dst=/cwac/config" \
   --mount "type=bind,src=./base_urls,dst=/cwac/base_urls" \
   --mount "type=bind,src=./results,dst=/cwac/results" \
-  -e CHROME_EXTRA_ARGS='--user-data-dir=/tmp,--no-sandbox,--disable-dev-shm-usage' \
+  -e CHROME_EXTRA_ARGS='--no-sandbox,--disable-dev-shm-usage' \
   $(cat /tmp/cwac_image_id) .venv/bin/python -u cwac.py config_e2e.json

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -5,7 +5,7 @@ set -e
 # create a url file
 cat <<URLS > base_urls/visit/e2e.csv
 organisation,url,sector
-e2e,example.com,e2e
+e2e,https://example.com,e2e
 URLS
 
 # create a config file

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -10,6 +10,7 @@ URLS
 
 # create a config file
 cat config/config_default.json | jq '
+  .audit_name = "e2e" |
   .max_links_per_domain = 3 |
   .filter_to_organisations = ["e2e"] |
   .filter_to_urls = ["example.com"]

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -18,7 +18,11 @@ cat config/config_default.json | jq '
 # make sure the "results" directory exists
 mkdir -p results
 
-docker build --iidfile /tmp/cwac_image_id .
+docker build \
+  --iidfile /tmp/cwac_image_id \
+  --build-arg USER_ID=$(id -u) \
+  --build-arg GROUP_ID=$(id -g) \
+  .
 
 docker run --rm \
   --mount "type=bind,src=./config,dst=/cwac/config" \

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -18,6 +18,9 @@ cat config/config_default.json | jq '
 # make sure the "results" directory exists
 mkdir -p results
 
+# make sure the package-lock.json exists
+npm i --package-lock-only
+
 docker build \
   --iidfile /tmp/cwac_image_id \
   --build-arg USER_ID=$(id -u) \

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -15,6 +15,9 @@ cat config/config_default.json | jq '
   .filter_to_urls = ["example.com"]
 ' > config/config_e2e.json
 
+# make sure the "results" directory exists
+mkdir -p results
+
 docker build --iidfile /tmp/cwac_image_id .
 
 docker run --rm \

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+# create a url file
+cat <<URLS > base_urls/visit/e2e.csv
+organisation,url,sector
+e2e,example.com,e2e
+URLS
+
+# create a config file
+cat config/config_default.json | jq '
+  .max_links_per_domain = 3 |
+  .filter_to_organisations = ["e2e"] |
+  .filter_to_urls = ["example.com"]
+' > config/config_e2e.json
+
+docker build --iidfile /tmp/cwac_image_id .
+
+docker run --rm \
+  --mount "type=bind,src=./config,dst=/cwac/config" \
+  --mount "type=bind,src=./base_urls,dst=/cwac/base_urls" \
+  --mount "type=bind,src=./results,dst=/cwac/results" \
+  -e CHROME_EXTRA_ARGS='--user-data-dir=/tmp,--no-sandbox,--disable-dev-shm-usage' \
+  $(cat /tmp/cwac_image_id) .venv/bin/python -u cwac.py config_e2e.json


### PR DESCRIPTION
This introduces a basic script for running the tool on `example.com` via docker so that we can ensure the tool works after changes, especially with dependency updates and image-specific changes which otherwise might not get caught for a while.

In future we should look at having a local-based site to scrap, but for now I think it's more important to have some CI in place so have used `example.com`