### PR TITLE
fix: explicitly allow `nltk_data` directory for downloading

### DIFF
--- a/src/audit_plugins/language_audit.py
+++ b/src/audit_plugins/language_audit.py
@@ -21,6 +21,7 @@ from src.audit_plugins.default_audit import DefaultAudit
 
 # Download Natural Language Toolkit data
 nltk_dir = os.getcwd() + '/nltk_data/'
+nltk.data.path.append(nltk_dir)
 nltk.download('punkt_tab', download_dir=nltk_dir, quiet=True)
 nltk.download('cmudict', download_dir=nltk_dir, quiet=True)
 nltk.download('vader_lexicon', download_dir=nltk_dir, quiet=True)


### PR DESCRIPTION
3.10.0 made strict path enforcing the default, meaning that [file-based resources must resolve within](https://github.com/nltk/nltk/security/policy#local-file-access):
1. `nltk.data.path` (configurable at runtime)
2. `NLTK_DATA` environment variable
3. Standard locations (`~/nltk_data`, `/usr/share/nltk_data`, etc.)
4. The system temp directory

Since we're storing the data in a custom directory we need to start explicitly allowing that by adding it to `nltk.data.path`