### PR TITLE
CWAC-254: ensure screenshot-based audits work in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ FROM --platform=linux/amd64 ubuntu:noble@sha256:723ad8033f109978f8c7e6421ee684ef
 # ubuntu equivalent (include upgrade)
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends wget python3-pip python3.12-venv libnss3-dev && \
+    apt-get install -y --no-install-recommends wget python3-pip python3.12-venv libnss3-dev libgl1 && \
     wget -nv https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
     apt-get install -y --no-install-recommends ./google-chrome-stable_current_amd64.deb && \
     apt-get clean && \

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -13,7 +13,8 @@ cat config/config_default.json | jq '
   .audit_name = "e2e" |
   .max_links_per_domain = 3 |
   .filter_to_organisations = ["e2e"] |
-  .filter_to_urls = ["example.com"]
+  .filter_to_urls = ["example.com"] |
+  .audit_plugins.screenshot_audit.enabled = true
 ' > config/config_e2e.json
 
 # make sure the "results" directory exists


### PR DESCRIPTION
Currently screenshots are failing since we don't have OpenGL available: https://github.com/GOVTNZ/cwac/actions/runs/29545522185/job/87776873583?pr=284

