### PR TITLE
refactor: remove unused `pyarrow` and `responses` dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ types-beautifulsoup4==4.12.0.20250516
 requests==2.34.2
 selenium==4.46.0
 lxml==6.1.1
-responses==0.26.2
 pre-commit==4.6.0
 bandit==1.9.4
 mypy==2.3.0
@@ -14,7 +13,6 @@ opencv-python==4.13.0.92
 numpy==2.5.1
 pandas==3.0.3
 pandas-stubs==3.0.3.260530
-pyarrow==24.0.0
 nltk==3.10.0
 pyfakefs==6.2.0
 pytest==9.1.1


### PR DESCRIPTION
* `pyarrow` is an optional dependency for `pandas` for reading parquet files
* `responses` is a package for mocking `requests`

As far as I can tell neither of these are being used (the `pandas` docs are not obvious, but it appears you do have to explicitly tell it to use `pyarrow`)