### PR TITLE
feat: update and pin `axe-core`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "chromeVersion": "122.0.6261.39"
   },
   "dependencies": {
-    "axe-core": "^4.10.2",
+    "axe-core": "4.12.1",
     "@mozilla/readability": "^0.6.0"
   }
 }


### PR DESCRIPTION
Since we don't have a lockfile, we should use an exact version to ensure the expected version is being used everywhere