### PR TITLE
CWAC-313: support reading sitemaps for urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,32 @@ Each plugin can have an optional `viewport_to_test` item, which allows you to
 run a plugin only at particular viewport sizes, if multiple are being tested.
 The value of this key must match a value within the `viewport_sizes` option.
 
+### Crawling sitemaps
+
+CWAC will attempt to crawl sitemaps if the `crawl_sitemaps` configuration option
+is `true`, which is the default.
+
+This is done using the
+[`ultimate-sitemap-parser`](https://ultimate-sitemap-parser.readthedocs.io/en/latest/get-started.html)
+library which includes support for
+
+- locating sitemaps via `robots.txt`
+- sitemaps compressed with gunzip (`.gz`)
+- [various sitemap locations](https://ultimate-sitemap-parser.readthedocs.io/en/latest/reference/api/usp.tree.html#usp.tree._UNPUBLISHED_SITEMAP_PATHS)
+- `sitemapindex`s
+
+It also comes with a
+[CLI](https://ultimate-sitemap-parser.readthedocs.io/en/latest/reference/cli.html)
+which can be useful in manually checking if sitemaps are set up correctly
+
+```
+$ usp ls https://example.org/
+  https://example.org/
+    https://example.org/robots.txt
+      https://example.org/sitemap.xml
+        https://example.org/page1.html
+```
+
 ## Updating Chrome and Chromedriver versions
 
 You can find the latest _Chrome for Testing_ version manually by visiting

--- a/config.py
+++ b/config.py
@@ -111,6 +111,8 @@ class Config:
     # if no entry is found for a website.
     self.robots_txt_cache: dict[str, urllib.robotparser.RobotFileParser] = {}
 
+    self.config.setdefault('crawl_sitemaps', True)
+
   def __setup_logger(self, log_filename: str) -> None:
     """Set up the CWAC logger for a new run.
 

--- a/config.py
+++ b/config.py
@@ -54,6 +54,7 @@ class Config:
   shuffle_base_urls: bool
   base_urls_visit_path: str
   base_urls_nohead_path: str
+  crawl_sitemaps: bool
   filter_to_organisations: list[str]
   filter_to_urls: list[str]
   viewport_sizes: dict[str, dict[str, int]]

--- a/config.py
+++ b/config.py
@@ -15,6 +15,8 @@ from urllib import parse
 
 logger = getLogger('cwac')
 
+getLogger('usp').parent = logger
+
 
 class SiteData(TypedDict):
   """Holds data for a site that should be crawled and audited."""

--- a/config.schema.json
+++ b/config.schema.json
@@ -103,6 +103,10 @@
       "type": "string",
       "minLength": 1
     },
+    "crawl_sitemaps": {
+      "description": "Whether to crawl sitemaps for base_urls, for additional URLs",
+      "type": "boolean"
+    },
     "record_unexpected_response_codes": {
       "description": "Whether to log and record unexpected HTTP response codes encountered during crawling",
       "type": "boolean"

--- a/config/config_default.json
+++ b/config/config_default.json
@@ -20,6 +20,7 @@
   "shuffle_base_urls": true,
   "base_urls_visit_path": "./base_urls/visit/",
   "base_urls_nohead_path": "./base_urls/nohead/",
+  "crawl_sitemaps": true,
   "record_unexpected_response_codes": true,
   "force_open_details_elements": true,
   "filter_to_organisations": [],

--- a/doc/plans/CWAC-313.md
+++ b/doc/plans/CWAC-313.md
@@ -1,0 +1,202 @@
+# [CWAC-313](https://ackama.atlassian.net/browse/CWAC-313): Support reading sitemaps via the tool
+
+## Background
+
+We want to add support for using sitemaps as part of crawling, because they let
+us discover pages that are not reachable by following links alone, e.g. because
+the site uses JS-based pagination, or they are only discoverable through
+searching.
+
+We want to focus on supporting XML based sitemaps as defined in the
+[sitemaps protocol](https://www.sitemaps.org/protocol.html).
+
+## Key Considerations
+
+### When to use the sitemap
+
+We will consider the sitemap when a configuration option such as
+`crawl_urls_from_sitemap` is `true`.
+
+This option will be `true` by default as we think it is desirable most of the
+time.
+
+### Fetching the sitemap
+
+Before crawling a particular `base_url`, we will attempt to request a sitemap
+from the root of the domain, first checking for a gzipped version of the sitemap
+(i.e. `/sitemap.xml.gz`) before checking for an uncompressed version (i.e.
+`/sitemap.xml`).
+
+i.e. if the `base_url` is `https://ackama.com/projects`, then we will look for
+`https://ackama.com/sitemap.xml.gz`, and then `https://ackama.com/sitemap.xml`.
+
+For `/sitemap.xml.gz`, if we receive a 200 response with a `Content-Type`
+indicating gzipped content (i.e. `application/x-gzip`, `application/gzip`), we
+will decode the content and attempt to parse it as XML. If that is successful,
+we will consider it a valid sitemap and attempt to convert it to a set of urls,
+or otherwise move on to trying `/sitemap.xml`.
+
+For `/sitemap.xml`, if we receive a 200 response with a `Content-Type`
+indicating XML content (i.e. `text/xml`), we will consider it a valid sitemap,
+and attempt to convert it to a set of urls.
+
+If we receive a redirect response for these requests, we will follow that
+redirect.
+
+These fetches will not be considered towards the `max_links_per_domain` limit.
+
+### Converting a sitemap to a set of URLs
+
+We will parse XML sitemaps per the
+[sitemap protocol](https://www.sitemaps.org/protocol.html).
+
+#### `urlset` sitemaps
+
+If the sitemap is a `urlset`, we will iterate over each `url` and push their
+`loc` value into the queue of urls to be processed for the `base_url`.
+
+Any other properties will be ignored.
+
+For example given this sitemap:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.example.com/</loc>
+    <lastmod>2005-01-01</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://www.example.com/catalog?item=12&amp;desc=vacation_hawaii</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+
+  <url>
+    <loc>https://www.example.com/catalog?item=73&amp;desc=vacation_new_zealand</loc>
+    <lastmod>2004-12-23</lastmod>
+    <changefreq>weekly</changefreq>
+  </url>
+
+  <url>
+    <loc>https://www.example.com/catalog?item=74&amp;desc=vacation_newfoundland</loc>
+    <lastmod>2004-12-23T18:00:15+00:00</lastmod>
+    <priority>0.3</priority>
+  </url>
+
+  <url>
+    <loc>https://www.example.com/catalog?item=83&amp;desc=vacation_usa</loc>
+    <lastmod>2004-11-23</lastmod>
+  </url>
+</urlset>
+```
+
+We would "crawl" the following:
+
+- https://www.example.com/
+- https://www.example.com/catalog?item=12&amp;desc=vacation_hawaii
+- https://www.example.com/catalog?item=73&amp;desc=vacation_new_zealand
+- https://www.example.com/catalog?item=74&amp;desc=vacation_newfoundland
+- https://www.example.com/catalog?item=83&amp;desc=vacation_usa
+
+#### `sitemapindex` sitemaps
+
+If the sitemap is a `sitemapindex`, we will iterate over each `sitemap`, fetch
+the sitemap pointed to by their `loc`, and then process them accordingly.
+
+Any other properties will be ignored.
+
+These fetches will not be considered towards the `max_links_per_domain` limit.
+
+For example given this sitemap:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+   <sitemap>
+      <loc>https://www.example.com/sitemap1.xml.gz</loc>
+      <lastmod>2004-10-01T18:23:17+00:00</lastmod>
+   </sitemap>
+
+   <sitemap>
+      <loc>https://www.example.com/sitemap2.xml.gz</loc>
+      <lastmod>2005-01-01</lastmod>
+   </sitemap>
+</sitemapindex>
+```
+
+We would process the following sitemaps:
+
+- https://www.example.com/sitemap1.xml.gz
+- https://www.example.com/sitemap2.xml.gz
+
+### Ordering and filtering urls added from sitemaps
+
+URLs sourced from sitemaps will be treated the same as those crawled from HTML
+pages, including:
+
+- being subject to the `max_links_per_domain` limit
+- being run through the URL filters
+- being checked against `robots.txt`
+- being checked for support headers
+- being scoped to the `base_url` to prevent intersections
+
+## Open Considerations
+
+### When to fetch the sitemap for urls
+
+Fetching the sitemap should most likely happen in the `Crawler`, and should only
+need to be done once per `base_url`.
+
+The current process within `Crawler#crawl` is:
+
+1. create a `RandomQueue` (`queue`) with the `base_url` as the only entry
+2. while the `queue` is not empty:
+   1. pop a random page url off the queue
+   2. check that we want to audit that page, `continue`ing if not
+      - including checking if we're reached the `max_links_per_domain` limit
+   3. audit the page
+   4. extract all links on the page, and push them into the queue
+
+Since we only need to fetch the sitemap once, we could do this before step 2.
+however since urls are popped off the queue at random, we risk not auditing the
+`base_url` before reaching the `max_links_per_domain` limit, which might be
+surprising.
+
+An alternative could be to fetch the sitemap within the loop before step 4. _if_
+the `queue` is empty, and we had not recorded any other urls as being `visited`
+(or if only the `base_url` had been visited), as that would indicate we were in
+the first iteration.
+
+An advantage to this is we'd avoid fetching the sitemap if the `base_url` was
+skipped for some reason, such as failing the header check.
+
+### Inspecting `robots.txt` for sitemaps
+
+It is common (but not required) for sites to specify the location of their
+sitemap(s) in their `robots.txt` file with the `Sitemap` directive:
+
+```text
+Sitemap: https://www.example.com/sitemap.xml
+```
+
+The CWAC tool does already support interacting with `robots.txt` using the
+built-in
+[`urllib.robotparser`](https://docs.python.org/3/library/urllib.robotparser.html)
+which does understand the `Sitemap` directive (via
+[`site_maps()`](https://docs.python.org/3/library/urllib.robotparser.html#urllib.robotparser.RobotFileParser.site_maps)).
+
+Using this could improve the tool when dealing with sitemaps:
+
+- sites that did not provide a gzipped version of their sitemap: we would not
+  need to make an initial request for the gzipped sitemap
+- sites that used an alternative sitemap location, and had a redirect: we would
+  not need to go through the redirect chain
+- sites that used an alternative sitemap location, and did not have a redirect:
+  we would be able to discover their sitemap
+
+However, it is not clear how this should interact with cases such as where
+`robots.txt` is unavailable or checking is disabled entirely (via the
+`follow_robots_txt` option), so it may be best to explore this separately.

--- a/doc/plans/CWAC-313.md
+++ b/doc/plans/CWAC-313.md
@@ -15,122 +15,24 @@ We want to focus on supporting XML based sitemaps as defined in the
 ### When to use the sitemap
 
 We will consider the sitemap when a configuration option such as
-`crawl_urls_from_sitemap` is `true`.
+`crawl_sitemaps` is `true`.
 
 This option will be `true` by default as we think it is desirable most of the
 time.
 
 ### Fetching the sitemap
 
-Before crawling a particular `base_url`, we will attempt to request a sitemap
-from the root of the domain, first checking for a gzipped version of the sitemap
-(i.e. `/sitemap.xml.gz`) before checking for an uncompressed version (i.e.
-`/sitemap.xml`).
+We will use the
+[`ultimate-sitemap-parser`](https://ultimate-sitemap-parser.readthedocs.io/en/latest/get-started.html)
+library, which looks like it does all the things we'd like including:
 
-i.e. if the `base_url` is `https://ackama.com/projects`, then we will look for
-`https://ackama.com/sitemap.xml.gz`, and then `https://ackama.com/sitemap.xml`.
+- locating sitemaps via `robots.txt`
+- sitemaps compressed with gunzip (`.gz`)
+- [various sitemap locations](https://ultimate-sitemap-parser.readthedocs.io/en/latest/reference/api/usp.tree.html#usp.tree._UNPUBLISHED_SITEMAP_PATHS)
+- `sitemapindex`s
 
-For `/sitemap.xml.gz`, if we receive a 200 response with a `Content-Type`
-indicating gzipped content (i.e. `application/x-gzip`, `application/gzip`), we
-will decode the content and attempt to parse it as XML. If that is successful,
-we will consider it a valid sitemap and attempt to convert it to a set of urls,
-or otherwise move on to trying `/sitemap.xml`.
-
-For `/sitemap.xml`, if we receive a 200 response with a `Content-Type`
-indicating XML content (i.e. `text/xml`), we will consider it a valid sitemap,
-and attempt to convert it to a set of urls.
-
-If we receive a redirect response for these requests, we will follow that
-redirect.
-
-These fetches will not be considered towards the `max_links_per_domain` limit.
-
-### Converting a sitemap to a set of URLs
-
-We will parse XML sitemaps per the
-[sitemap protocol](https://www.sitemaps.org/protocol.html).
-
-#### `urlset` sitemaps
-
-If the sitemap is a `urlset`, we will iterate over each `url` and push their
-`loc` value into the queue of urls to be processed for the `base_url`.
-
-Any other properties will be ignored.
-
-For example given this sitemap:
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://www.example.com/</loc>
-    <lastmod>2005-01-01</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-  <url>
-    <loc>https://www.example.com/catalog?item=12&amp;desc=vacation_hawaii</loc>
-    <changefreq>weekly</changefreq>
-  </url>
-
-  <url>
-    <loc>https://www.example.com/catalog?item=73&amp;desc=vacation_new_zealand</loc>
-    <lastmod>2004-12-23</lastmod>
-    <changefreq>weekly</changefreq>
-  </url>
-
-  <url>
-    <loc>https://www.example.com/catalog?item=74&amp;desc=vacation_newfoundland</loc>
-    <lastmod>2004-12-23T18:00:15+00:00</lastmod>
-    <priority>0.3</priority>
-  </url>
-
-  <url>
-    <loc>https://www.example.com/catalog?item=83&amp;desc=vacation_usa</loc>
-    <lastmod>2004-11-23</lastmod>
-  </url>
-</urlset>
-```
-
-We would "crawl" the following:
-
-- https://www.example.com/
-- https://www.example.com/catalog?item=12&amp;desc=vacation_hawaii
-- https://www.example.com/catalog?item=73&amp;desc=vacation_new_zealand
-- https://www.example.com/catalog?item=74&amp;desc=vacation_newfoundland
-- https://www.example.com/catalog?item=83&amp;desc=vacation_usa
-
-#### `sitemapindex` sitemaps
-
-If the sitemap is a `sitemapindex`, we will iterate over each `sitemap`, fetch
-the sitemap pointed to by their `loc`, and then process them accordingly.
-
-Any other properties will be ignored.
-
-These fetches will not be considered towards the `max_links_per_domain` limit.
-
-For example given this sitemap:
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-   <sitemap>
-      <loc>https://www.example.com/sitemap1.xml.gz</loc>
-      <lastmod>2004-10-01T18:23:17+00:00</lastmod>
-   </sitemap>
-
-   <sitemap>
-      <loc>https://www.example.com/sitemap2.xml.gz</loc>
-      <lastmod>2005-01-01</lastmod>
-   </sitemap>
-</sitemapindex>
-```
-
-We would process the following sitemaps:
-
-- https://www.example.com/sitemap1.xml.gz
-- https://www.example.com/sitemap2.xml.gz
+It also has a CLI for listing sitemaps locally, which can be useful for
+debugging
 
 ### Ordering and filtering urls added from sitemaps
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ pyfakefs==6.2.0
 pytest==9.1.1
 pytest-mock==3.15.1
 ruff==0.16.1
+ultimate-sitemap-parser==1.8.1

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -634,7 +634,11 @@ class Crawler:
     """Crawls the urls sitemap, if there is one."""
     logger.info('Fetching sitemap for %s', url)
 
-    tree = sitemap_tree_for_homepage(url)
+    try:
+      tree = sitemap_tree_for_homepage(url)
+    except Exception:
+      logger.exception('Failed to get sitemap')
+      return []
 
     parents_and_urls = []
 

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -523,13 +523,7 @@ class Crawler:
       logger.error('base_url was filtered out! %s', base_url)
       return
 
-    if self.config.crawl_sitemaps:
-      urls_from_sitemap = self.__crawl_sitemap(base_url)
-
-      logger.info('Found %i url%s from sitemaps', len(urls_from_sitemap), '' if len(urls_from_sitemap) == 1 else 's')
-
-      for parent_and_url in urls_from_sitemap:
-        queue.push(parent_and_url)
+    has_crawled_sitemap = not self.config.crawl_sitemaps
 
     while queue:
       parent_url, url = queue.pop()
@@ -611,6 +605,17 @@ class Crawler:
       # don't bother getting links if we are only scanning one link per base url
       if self.config.max_links_per_domain == 1:
         break
+
+      # we delay crawling the sitemap for urls until after the base_url has been
+      # audited to ensure that has happened since the queue provides urls at random
+      if len(queue) == 0 and not has_crawled_sitemap:
+        urls_from_sitemap = self.__crawl_sitemap(base_url)
+
+        logger.info('Found %i url%s from sitemaps', len(urls_from_sitemap), '' if len(urls_from_sitemap) == 1 else 's')
+
+        for parent_and_url in urls_from_sitemap:
+          queue.push(parent_and_url)
+        has_crawled_sitemap = True
 
       links = self.get_links(base_url, url)
 

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -523,12 +523,13 @@ class Crawler:
       logger.error('base_url was filtered out! %s', base_url)
       return
 
-    urls_from_sitemap = self.__crawl_sitemap(base_url)
+    if self.config.crawl_sitemaps:
+      urls_from_sitemap = self.__crawl_sitemap(base_url)
 
-    logger.info('Found %i url%s from sitemaps', len(urls_from_sitemap), '' if len(urls_from_sitemap) == 1 else 's')
+      logger.info('Found %i url%s from sitemaps', len(urls_from_sitemap), '' if len(urls_from_sitemap) == 1 else 's')
 
-    for parent_and_url in urls_from_sitemap:
-      queue.push(parent_and_url)
+      for parent_and_url in urls_from_sitemap:
+        queue.push(parent_and_url)
 
     while queue:
       parent_url, url = queue.pop()

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -496,7 +496,6 @@ class Crawler:
         base_url (str): the first url to crawl
     """
     action = 'crawl'
-    # todo: come back to this case
     if self.config.max_links_per_domain == 1:
       action = 'visit'
     logger.info('Starting %s of %s', action, base_url)

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -10,6 +10,7 @@ import random
 import re
 import time
 import urllib
+import urllib.parse
 import urllib.robotparser
 from queue import SimpleQueue
 from typing import Tuple
@@ -17,6 +18,7 @@ from typing import Tuple
 import requests
 import selenium.common.exceptions
 from bs4 import BeautifulSoup
+from usp.tree import sitemap_tree_for_homepage
 
 import src.filters
 import src.output
@@ -31,7 +33,6 @@ from src.output import CSVWriter
 
 
 logger = logging.getLogger('cwac')
-
 
 type SiteData = ConfigSiteData
 
@@ -495,6 +496,7 @@ class Crawler:
         base_url (str): the first url to crawl
     """
     action = 'crawl'
+    # todo: come back to this case
     if self.config.max_links_per_domain == 1:
       action = 'visit'
     logger.info('Starting %s of %s', action, base_url)
@@ -520,6 +522,13 @@ class Crawler:
       self.record_pages_scanned(site_data, pages_scanned)
       logger.error('base_url was filtered out! %s', base_url)
       return
+
+    urls_from_sitemap = self.__crawl_sitemap(base_url)
+
+    logger.info('Found %i url%s from sitemaps', len(urls_from_sitemap), '' if len(urls_from_sitemap) == 1 else 's')
+
+    for parent_and_url in urls_from_sitemap:
+      queue.push(parent_and_url)
 
     while queue:
       parent_url, url = queue.pop()
@@ -615,6 +624,20 @@ class Crawler:
     self.record_pages_scanned(site_data, pages_scanned)
     if self.config.max_links_per_domain != 1:
       logger.info('Crawl exhausted all links %s', base_url)
+
+  def __crawl_sitemap(self, url: str) -> list[Tuple[str, str]]:
+    """Crawls the urls sitemap, if there is one."""
+    logger.info('Fetching sitemap for %s', url)
+
+    tree = sitemap_tree_for_homepage(url)
+
+    parents_and_urls = []
+
+    for sitemap in tree.all_sitemaps():
+      for page in sitemap.all_pages():
+        parents_and_urls.append((sitemap.url, page.url))
+
+    return parents_and_urls
 
   def record_pages_scanned(self, site_data: SiteData, pages_scanned: int) -> None:
     """Record the number of pages that were scanned for the site."""


### PR DESCRIPTION
This uses [`ultimate-sitemap-parser`](https://ultimate-sitemap-parser.readthedocs.io/en/latest/get-started.html) to "crawl" urls from the sitemap of each base url