### PR TITLE
build: switch to `opencv-python-headless`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ mypy==2.3.0
 pylint==4.0.6
 flake8==7.3.0
 flake8-simplify==0.30.0
-opencv-python==5.0.0.93
+opencv-python-headless==5.0.0.93
 numpy==2.5.1
 pandas==3.0.3
 pandas-stubs==3.0.3.260530


### PR DESCRIPTION
This is the "CPU-only version" of the package, which from what I can tell means "does not have GUI related dependencies" so it's slightly smaller, and should work for us because we're using it in a "server" context rather than as a desktop application