### PR TITLE
build: avoid installing chrome itself via apt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,13 @@ RUN npm install
 
 FROM --platform=linux/amd64 ubuntu:noble@sha256:723ad8033f109978f8c7e6421ee684efb624eb5b9251b70c6788fdb2405d050b
 
-# ubuntu equivalent (include upgrade)
+# install the dependencies we need for running Python and Chrome, while avoiding installing
+# Chrome itself since that gets managed using @puppeteer/browsers as part of the npm install
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends wget python3-pip python3.12-venv libnss3-dev libgl1 && \
     wget -nv https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
-    apt-get install -y --no-install-recommends ./google-chrome-stable_current_amd64.deb && \
+    apt-get satisfy -y --no-install-recommends "$(dpkg-deb -f google-chrome-stable_current_amd64.deb Depends | tr '\n' ' ')" && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives && \
     rm google-chrome-stable_current_amd64.deb


### PR DESCRIPTION
Right now we're actually installing Chrome twice: once via `apt-get` (which ensures we have all the OS dependencies Chrome needs to run), and second as part of `npm install` using `@puppeteer/browsers` (which ensures we're using a specific version of Chrome).

This switches us to using the Chrome `deb` to install the OS dependencies, without installing the `deb` itself, which should shave about ~300mb off the docker image