### PR TITLE
build: move off legacy `ENV` syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ WORKDIR /cwac
 # create .venv
 RUN python3 -m venv .venv
 
-ENV VIRTUAL_ENV .venv
-ENV PATH .venv/bin:$PATH
+ENV VIRTUAL_ENV=".venv" \
+    PATH=".venv/bin:$PATH"
 
 # copy in requirements.txt
 COPY requirements.txt .


### PR DESCRIPTION
This addresses [LegacyKeyValueFormat](https://docs.docker.com/reference/build-checks/legacy-key-value-format/), which is a deprecated syntax. I've also merged the lines and wrapped the values in quotes as that's more consistent with what we do elsewhere, and I just generally prefer this layout

We do still get a warning from Docker regarding the hardcoded `FROM --platform` which triggers [FromPlatformFlagConstDisallowed](https://docs.docker.com/reference/build-checks/from-platform-flag-const-disallowed/), but I think for now that's the right thing for us to be doing because the Docker file very much expects to be on an amd host