### PR TITLE
build: don't install `libnss3` headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=linux/amd64 ubuntu:noble@sha256:723ad8033f109978f8c7e6421ee684ef
 # Chrome itself since that gets managed using @puppeteer/browsers as part of the npm install
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends wget python3.12-venv libnss3-dev libgl1 && \
+    apt-get install -y --no-install-recommends wget python3.12-venv libgl1 && \
     wget -nv https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
     apt-get satisfy -y --no-install-recommends "$(dpkg-deb -f google-chrome-stable_current_amd64.deb Depends | tr '\n' ' ')" && \
     apt-get clean && \


### PR DESCRIPTION
We're already installing the required `libnss3` dependency through the `apt-get satisfy ... Depends` line, so this is just pulling in the headers for no real