### PR TITLE
build: uninstall some Python dependencies we don't need

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,9 @@ ENV VIRTUAL_ENV=".venv" \
 # copy in requirements.txt
 COPY requirements.txt .
 
-# pip install
-RUN python3.12 -m pip install --no-cache-dir -r requirements.txt
+# install dependencies, and then remove stuff we don't need when running the tool
+RUN python3.12 -m pip install --no-cache-dir -r requirements.txt && \
+    python3 -m pip uninstall -y ruff mypy pre-commit pyfakefs pytest pytest-mock pip
 
 # copy node_modules from node_modules_builder
 COPY --from=node_modules_builder /usr/app/node_modules ./node_modules


### PR DESCRIPTION
Since we're using a single `requirements.txt` file, we currently include a bunch of dev-only dependencies which includes `ruff` and `mypy` which are both about ~4mb each.

I've updated our install step to remove some of these, including `pip` itself since we shouldn't need it once we've got our dependencies installed.

I've not listed every single dependency because most of the remaining ones are superseded by `ruff` and are just being kept around short-term to showcase potential differences.

I've also not split this into separate files or converted us to e.g. `uv` because I'm focusing on easy wins, and our dependency setup is working fine so I don't think we need to be super aggressive about this