### PR TITLE
docs: make callouts valid

### DIFF
--- a/doc/audit-config.md
+++ b/doc/audit-config.md
@@ -139,12 +139,14 @@ The available configuration options are described below. See the
 
 ## CSV files of base URLs to visit
 
-> [!TIP] Ignore advanced configurations for now. There are advanced
-> configurations of CWAC that use other CSV files - see the settings for
-> `base_urls_nohead_path` above. You can ignore these when getting started - the
-> only CSV file actually required is the "visits" CSV (described below) As well
-> as the JSON configuration, CWAC needs a CSV file with a set of base URLs that
-> will be visited, crawled and scanned.
+> [!TIP]
+>
+> Ignore advanced configurations for now. There are advanced configurations of
+> CWAC that use other CSV files - see the settings for `base_urls_nohead_path`
+> above. You can ignore these when getting started - the only CSV file actually
+> required is the "visits" CSV (described below) As well as the JSON
+> configuration, CWAC needs a CSV file with a set of base URLs that will be
+> visited, crawled and scanned.
 
 These lists of URLs to visit are loaded from every `.csv` file stored under
 `base_urls/visit`. This provides a lot of flexibility when scanning multiple

--- a/doc/audit-results.md
+++ b/doc/audit-results.md
@@ -43,7 +43,9 @@ results/2026-07-14_13-53-12_5
 All audit results are stored as CSV files. These files contain the accessibility
 findings discovered by the scan.
 
-> [!WARNING] All CSV files start with Byte-order Mark (BOM) All generated CSV
+> [!WARNING]
+>
+> All CSV files start with Byte-order Mark (BOM) All generated CSV
 > files start with 3 hidden bytes called a
 > [BOM marker](https://en.wikipedia.org/wiki/Byte_order_mark). The BOM allows MS
 > Excel to choose the correct character set for the data and thereby avoid

--- a/doc/run-cwac.md
+++ b/doc/run-cwac.md
@@ -21,5 +21,6 @@ python cwac.py
 python cwac.py config_custom.json
 ```
 
-> [!WARNING] JSON configuration files must always be located in the `./config/`
-> directory.
+> [!WARNING]
+>
+> JSON configuration files must always be located in the `./config/` directory.


### PR DESCRIPTION
Callouts cannot have next to them