### PR TITLE
build: remove test files after installing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,11 @@ ENV VIRTUAL_ENV=".venv" \
 # copy in requirements.txt
 COPY requirements.txt .
 
-# install dependencies, and then remove stuff we don't need when running the tool
+# install dependencies, and then remove stuff we don't need when running the tool,
+# along with test files as they can be quite large for dependencies like pandas
 RUN python3.12 -m pip install --no-cache-dir -r requirements.txt && \
-    python3 -m pip uninstall -y ruff mypy pre-commit pyfakefs pytest pytest-mock pip
+    python3 -m pip uninstall -y ruff mypy pre-commit pyfakefs pytest pytest-mock pip && \
+    find .venv/lib -depth -type d \( -name tests -o -name test \) -exec rm -rf -- {} +
 
 # copy node_modules from node_modules_builder
 COPY --from=node_modules_builder /usr/app/node_modules ./node_modules


### PR DESCRIPTION
Some of our dependencies ship with test files which we don't need, and can be quite large - for example, `pandas/tests` is 37mb