### PR TITLE
CWAC-333: Audits should not exit program if they cannot be run due to configuration issues

### DIFF
--- a/src/audit_plugins/axe_core_audit.py
+++ b/src/audit_plugins/axe_core_audit.py
@@ -54,8 +54,12 @@ class AxeCoreAudit(DefaultAudit):
           logger.info('Reading axe.min.js')
           axe_min_js = file.read()
       except FileNotFoundError:
-        logger.exception('axe.min.js not found. Please run `npm install`')
-        print('axe.min.js not found. Please run `npm install`')
+        msg = 'axe.min.js not found. Please run `npm install`'
+        logger.error(msg)
+        print(msg)
+
+        # Being unable to load axe.min.js indicates a misconfigured environment
+        # that we cannot recover from, so exit the program.
         sys.exit(1)
       run_axe = (
         'var callback = arguments[arguments.length - 1];'

--- a/src/audit_plugins/focus_indicator_audit.py
+++ b/src/audit_plugins/focus_indicator_audit.py
@@ -7,7 +7,6 @@ changed, then the focus indicator is invisible.
 """
 
 import logging
-import sys
 import time
 from typing import Any
 
@@ -157,7 +156,10 @@ class FocusIndicatorAudit(DefaultAudit):
     if not self.config.headless:
       logger.error('ERROR: FocusIndicatorAudit needs headless=True in config.json')
       print('ERROR: FocusIndicatorAudit needs headless=True in config.json')
-      sys.exit(1)
+
+      # We cannot run this audit so return letting AuditManager know that the
+      # audit failed
+      return False
 
     original_window_size = self.browser.driver.get_window_size()
 

--- a/src/audit_plugins/focus_indicator_audit.py
+++ b/src/audit_plugins/focus_indicator_audit.py
@@ -156,9 +156,6 @@ class FocusIndicatorAudit(DefaultAudit):
     if not self.config.headless:
       logger.error('ERROR: FocusIndicatorAudit needs headless=True in config.json')
       print('ERROR: FocusIndicatorAudit needs headless=True in config.json')
-
-      # We cannot run this audit so return letting AuditManager know that the
-      # audit failed
       return False
 
     original_window_size = self.browser.driver.get_window_size()

--- a/src/audit_plugins/reflow_audit.py
+++ b/src/audit_plugins/reflow_audit.py
@@ -15,7 +15,6 @@ Disclaimer:
 """
 
 import logging
-import sys
 from typing import Any
 
 from config import Config
@@ -58,16 +57,17 @@ class ReflowAudit(DefaultAudit):
     """
     if not self.config.headless:
       # Log an error and quit
-      logger.error('Headless mode must be enabled for ReflowAudit.')
-      print('Headless mode must be enabled for ReflowAudit.')
-      sys.exit(1)
+      msg = 'Headless mode must be enabled for ReflowAudit.'
+      logger.error(msg)
+      print(msg)
+      return False
 
     # If browser is not 320px wide
     if self.browser.driver.get_window_size()['width'] != 320:
-      logger.error('ReflowAudit must only run at 320px wide')
-      print('ReflowAudit must only run at 320px wide')
-      print('Width was ' + str(self.browser.driver.get_window_size()['width']))
-      sys.exit(1)
+      msg = f'ReflowAudit must only run at 320px wide. Width was {self.browser.driver.get_window_size()["width"]}'
+      logger.error(msg)
+      print(msg)
+      return False
 
     # Determine if there is a horisontal overflow
     try:


### PR DESCRIPTION
In general, it is not appropriate for individual audits to end the program if the encounter an error because that error could be localised to that audit or that audit on a particular URL, in which cases the user would not expect the whole scan to stop.

There is one exception to this, in that `AxeCoreAudit` does exit the program is the `axe.min.js` cannot be found. I made a judgement call to keep this based on

1. Running Axe-core is sufficiently core to the purpose of this project
2. A missing `axe.min.js` indicates a misconfiguration that will likely also cause other errors which might manifest in less obvious ways. Exiting early and letting the user fix the issue seems appropriate in this case.