### PR TITLE
CWAC-327: make "organisation" and "sector" columns optional

### DIFF
--- a/config.py
+++ b/config.py
@@ -245,15 +245,14 @@ class Config:
             except ValueError as e:
               raise ValueError(f"{filename} has a row whose columns don't match the headers: {row}") from e
 
-            url = columns.get('url')
-            if not url:
-              raise ValueError(f'{filename} has a row whose "url" column is blank: {row}')
-
             subject = SiteData(
-              url=url,
+              url=columns['url'],
               supports_head=True,
               columns=columns,
             )
+
+            if not subject['url']:
+              raise ValueError(f'{filename} has a row whose "url" column is blank: {row}')
 
             # Parse the URL to get just the domain
             parsed_url = parse.urlparse(subject['url'])

--- a/config.py
+++ b/config.py
@@ -103,6 +103,7 @@ class Config:
 
     self.audit_subjects: list[SiteData] = self.__import_base_urls()
 
+    # todo: see if we can remove this?
     self.url_lookup = self.__map_base_urls_by_domain()
 
     # global variable to store robots.txt data
@@ -362,34 +363,8 @@ class Config:
       # Write the config file to the results folder
       return json.load(file)
 
-  def lookup_organisation(self, url: str) -> dict[str, str]:
-    """Lookup the agency details from a URL.
-
-    Args:
-        url (str): the URL to lookup
-
-    Returns:
-        dict[str, str]: a dictionary with "organisation" and
-        "sector" as the keys, and the agency name and sector as
-        the values.
-    """
-    # Parse the URL to get just the domain
-    parsed_url = parse.urlparse(url)
-    domain = parsed_url.netloc.lower()
-
-    if domain not in self.url_lookup:
-      logger.warning('Agency data missing for: %s', url)
-      return {'organisation': 'Unknown', 'sector': 'Unknown'}
-    return {
-      'organisation': self.url_lookup[domain]['organisation'],
-      'sector': self.url_lookup[domain]['sector'],
-    }
-
   def __map_base_urls_by_domain(self) -> dict[str, dict[str, str]]:
     """Build a dictionary mapping base url information to their domain.
-
-    This data is primarily used for looking up the agency details
-    given a URL by using the lookup_organisation() method.
 
     Returns:
         dict[str, dict[str, str]]: a dictionary with the URL as the key,

--- a/config.py
+++ b/config.py
@@ -270,6 +270,14 @@ class Config:
 
             subjects.append(subject)
 
+    columns = sorted(set().union(*[subject['columns'].keys() for subject in subjects]))
+
+    # ensure each site has the same columns, otherwise
+    # we'll get errors when trying to write our csvs
+    for subject in subjects:
+      for column in columns:
+        subject['columns'].setdefault(column, '')
+
     return subjects
 
   def __resolve_automatic_settings(self) -> None:

--- a/config.py
+++ b/config.py
@@ -22,7 +22,6 @@ class SiteData(TypedDict):
   """Holds data for a site that should be crawled and audited."""
 
   url: str
-  sector: str
   supports_head: bool
   columns: dict[str, str]
 
@@ -240,7 +239,6 @@ class Config:
 
             subject = SiteData(
               url=columns['url'],
-              sector=columns['sector'],
               supports_head=True,
               columns=columns,
             )
@@ -410,9 +408,7 @@ class Config:
       # Strip whitespace
       domain = domain.strip()
 
-      base_urls[domain] = {
-        'sector': subject['sector'],
-      }
+      base_urls[domain] = {}
     return base_urls
 
   def is_path_subdir(self, path: str, parent_path: str) -> bool:

--- a/config.py
+++ b/config.py
@@ -103,8 +103,8 @@ class Config:
 
     self.audit_subjects: list[SiteData] = self.__import_base_urls()
 
-    # todo: see if we can remove this?
-    self.url_lookup = self.__map_base_urls_by_domain()
+    # store a set of normalized domains
+    self.url_lookup = {parse.urlparse(subject['url']).netloc.lower().strip() for subject in self.audit_subjects}
 
     # global variable to store robots.txt data
     # the Crawler queries this and populates it
@@ -370,29 +370,6 @@ class Config:
     with open('./config/' + config_filename, encoding='utf-8-sig') as file:
       # Write the config file to the results folder
       return json.load(file)
-
-  def __map_base_urls_by_domain(self) -> dict[str, dict[str, str]]:
-    """Build a dictionary mapping base url information to their domain.
-
-    Returns:
-        dict[str, dict[str, str]]: a dictionary with the URL as the key,
-        and a list that contains the agency name, and the sector
-        as the value.
-    """
-    base_urls: dict[str, dict[str, str]] = {}
-
-    for subject in self.audit_subjects:
-      # Parse the URL to get just the domain
-      parsed_url = parse.urlparse(subject['url'])
-
-      # Cast to lowercase
-      domain = parsed_url.netloc.lower()
-
-      # Strip whitespace
-      domain = domain.strip()
-
-      base_urls[domain] = {}
-    return base_urls
 
   def is_path_subdir(self, path: str, parent_path: str) -> bool:
     """Check if a path is a subdirectory of another path.

--- a/config.py
+++ b/config.py
@@ -21,7 +21,6 @@ getLogger('usp').parent = logger
 class SiteData(TypedDict):
   """Holds data for a site that should be crawled and audited."""
 
-  organisation: str
   url: str
   sector: str
   supports_head: bool
@@ -200,7 +199,7 @@ class Config:
     found_org = False
     if self.filter_to_organisations:
       for org in self.filter_to_organisations:
-        if org in row['organisation']:
+        if org in row['columns'].get('organisation', ''):
           found_org = True
           break
 
@@ -240,7 +239,6 @@ class Config:
             columns = dict(zip(header, row, strict=True))
 
             subject = SiteData(
-              organisation=columns['organisation'],
               url=columns['url'],
               sector=columns['sector'],
               supports_head=True,
@@ -413,7 +411,6 @@ class Config:
       domain = domain.strip()
 
       base_urls[domain] = {
-        'organisation': subject['organisation'],
         'sector': subject['sector'],
       }
     return base_urls

--- a/config.py
+++ b/config.py
@@ -236,7 +236,10 @@ class Config:
           reader = csv.reader(file)
           header = next(reader)
           for row in reader:
-            columns = dict(zip(header, row, strict=True))
+            try:
+              columns = dict(zip(header, row, strict=True))
+            except ValueError as e:
+              raise ValueError(f"{filename} has a row whose columns don't match the headers: {row}") from e
 
             subject = SiteData(
               url=columns['url'],

--- a/config.py
+++ b/config.py
@@ -235,6 +235,10 @@ class Config:
         ) as file:
           reader = csv.reader(file)
           header = next(reader)
+
+          if 'url' not in header:
+            raise ValueError(f'{filename} does not have the required "url" header')
+
           for row in reader:
             try:
               columns = dict(zip(header, row, strict=True))
@@ -242,8 +246,8 @@ class Config:
               raise ValueError(f"{filename} has a row whose columns don't match the headers: {row}") from e
 
             url = columns.get('url')
-            if url is None:
-              raise ValueError(f'{filename} does not have the required "url" column')
+            if not url:
+              raise ValueError(f'{filename} has a row whose "url" column is blank: {row}')
 
             subject = SiteData(
               url=url,

--- a/config.py
+++ b/config.py
@@ -25,6 +25,7 @@ class SiteData(TypedDict):
   url: str
   sector: str
   supports_head: bool
+  columns: dict[str, str]
 
 
 class Config:
@@ -236,7 +237,15 @@ class Config:
           reader = csv.reader(file)
           header = next(reader)
           for row in reader:
-            subject = cast(SiteData, dict(zip(header, row, strict=True)))
+            columns = dict(zip(header, row, strict=True))
+
+            subject = SiteData(
+              organisation=columns['organisation'],
+              url=columns['url'],
+              sector=columns['sector'],
+              supports_head=True,
+              columns=columns,
+            )
 
             # Parse the URL to get just the domain
             parsed_url = parse.urlparse(subject['url'])
@@ -258,6 +267,7 @@ class Config:
               continue
 
             subject['url'] = self.__normalize_url(subject['url'])
+            subject['columns']['url'] = subject['url']
 
             subject['supports_head'] = subject['url'] not in headless_base_urls
 

--- a/config.py
+++ b/config.py
@@ -236,13 +236,6 @@ class Config:
           reader = csv.reader(file)
           header = next(reader)
           for row in reader:
-            if len(row) != 3:
-              raise ValueError(
-                'CSV files must have 3 columns',
-                row,
-                filename,
-              )
-
             subject = cast(SiteData, dict(zip(header, row, strict=True)))
 
             # Parse the URL to get just the domain

--- a/config.py
+++ b/config.py
@@ -241,8 +241,12 @@ class Config:
             except ValueError as e:
               raise ValueError(f"{filename} has a row whose columns don't match the headers: {row}") from e
 
+            url = columns.get('url')
+            if url is None:
+              raise ValueError(f'{filename} does not have the required "url" column')
+
             subject = SiteData(
-              url=columns['url'],
+              url=url,
               supports_head=True,
               columns=columns,
             )

--- a/config.py
+++ b/config.py
@@ -270,12 +270,12 @@ class Config:
 
             subjects.append(subject)
 
-    columns = sorted(set().union(*[subject['columns'].keys() for subject in subjects]))
+    all_columns = sorted(set().union(*[subject['columns'].keys() for subject in subjects]))
 
     # ensure each site has the same columns, otherwise
     # we'll get errors when trying to write our csvs
     for subject in subjects:
-      for column in columns:
+      for column in all_columns:
         subject['columns'].setdefault(column, '')
 
     return subjects

--- a/doc/plans/CWAC-327.md
+++ b/doc/plans/CWAC-327.md
@@ -25,33 +25,16 @@ impactful for crawling and auditing, and are not meaningful in all use cases.
 We will remove the requirement that there be three columns in the
 `base_urls/visit` CSVs, and instead enforce that there is a `url` column.
 
+After parsing, we will ensure that all rows have the same columns to ensure they
+can be written as CSVs.
+
 ### Filtering
 
-We will replace the `filter_to_organisations` and `filter_to_urls` configuration
-properties with a single `filters` object whose keys are column names.
+We will leave the `filter_to_organisations` and `filter_to_urls` configuration
+properties alone, since they will both continue to work.
 
-Each value will be an array of strings, and any row whose column value is not in
-the array will be skipped.
-
-For example, given a configuration like this:
-
-```json
-{
-  "filter_to_organisations": ["ACME"],
-  "filter_to_urls": ["https://example.com"]
-}
-```
-
-This would be changed to:
-
-```json
-{
-  "filters": {
-    "organisation": ["ACME"],
-    "url": ["https://example.com"]
-  }
-}
-```
+We will ensure that the handling of `filter_to_organisations` accounts for the
+column potentially not being present.
 
 ### Sorting
 
@@ -70,6 +53,10 @@ This will allow developers to add arbitrary columns, and preserve the
 ## Questions
 
 ### What if a column is not present in all CSVs?
+
+> [!NOTE]
+>
+> It was decided to go with Option 2
 
 The `CSVWriter` will error if rows don't all have the same columns.
 
@@ -104,28 +91,60 @@ Cons:
 
 - Ordering might be off at times?
 
-### What should we do with existing configurations?
+### What should we do with the `filter_to_organisations` property?
+
+> [!NOTE]
+>
+> It was decided to go with Option 1
+
+With "organisation" becoming optional, this filter property is a bit awkward.
 
 #### Option 1: do nothing
 
 Pros:
 
-- We'll be able to move away from the old properties faster
+- we don't have to worry about breaking existing configurations
+- the filter will still continue to work if the column is present
 
 Cons:
 
-- Developers will need to update their configurations
-- Wrappers of the tool (such as web applications) will need to ensure their
-  configurations are migrated
+- no ways to filter by other columns
 
-#### Option 1: support mapping `filter_to_organisations` and `filter_to_urls` to `filters`
+#### Option 2: replace with a more flexible `filters` feature
+
+We could replace both `filter_to_organisations` and `filter_to_urls` with a
+single `filters` object whose keys are column names.
+
+Each value would be an array of strings, and any row whose column value is not
+in the array would be skipped.
+
+For example, given a configuration like this:
+
+```json
+{
+  "filter_to_organisations": ["ACME"],
+  "filter_to_urls": ["https://example.com"]
+}
+```
+
+This would be changed to:
+
+```json
+{
+  "filters": {
+    "organisation": ["ACME"],
+    "url": ["https://example.com"]
+  }
+}
+```
 
 Pros:
 
-- Developers won't need to immediately change their configurations
+- not specific to the "organisations" column
+- would reduce the total number of configuration properties by one
 
 Cons:
 
-- we will want to remove these eventually
+- would break existing configurations
 
 ## Appendix

--- a/doc/plans/CWAC-327.md
+++ b/doc/plans/CWAC-327.md
@@ -1,0 +1,131 @@
+# [CWAC-327](https://ackama.atlassian.net/browse/CWAC-327): Make "organisation" and "sector" columns optional
+
+## Background
+
+We want to make it easier for developers to run scans, and ensure the
+information in the results is useful.
+
+Currently, the `base_urls/visit` CSVs follow this structure:
+
+```csv
+organisation,url,sector
+demo,https://broken-workshop.dequelabs.com/,demo
+demo,https://dequeuniversity.com/demo/dream,demo
+demo,https://webtestingcourse.dequecloud.com/,demo
+demo,https://dequeuniversity.com/demo/mars/,demo
+```
+
+The "organisation" and "sector" columns are required even though they're not
+impactful for crawling and auditing, and are not meaningful in all use cases.
+
+## Behaviours
+
+### Parsing
+
+We will remove the requirement that there be three columns in the
+`base_urls/visit` CSVs, and instead enforce that there is a `url` column.
+
+### Filtering
+
+We will replace the `filter_to_organisations` and `filter_to_urls` configuration
+properties with a single `filters` object whose keys are column names.
+
+Each value will be an array of strings, and any row whose column value is not in
+the array will be skipped.
+
+For example, given a configuration like this:
+
+```json
+{
+  "filter_to_organisations": ["ACME"],
+  "filter_to_urls": ["https://example.com"]
+}
+```
+
+This would be changed to:
+
+```json
+{
+  "filters": {
+    "organisation": ["ACME"],
+    "url": ["https://example.com"]
+  }
+}
+```
+
+### Sorting
+
+We will no longer use the "organisation" column or any other optional columns
+when sorting in the template-aware CSV. This mirrors the other output CSVs which
+are not sorted by any columns.
+
+### Outputs
+
+We will copy all columns that are present in the `base_urls` CSVs into our
+output CSVs, including the `url`.
+
+This will allow developers to add arbitrary columns, and preserve the
+"organisation" and "sector" columns that some developers might be using.
+
+## Questions
+
+### What if a column is not present in all CSVs?
+
+The `CSVWriter` will error if rows don't all have the same columns.
+
+#### Option 1: reject if CSVs don't have the same columns
+
+When processing the CSVs, we could raise an error if we found columns not
+present in all CSVs.
+
+Pros:
+
+- Developers would receive immediate feedback
+
+Cons:
+
+- Wrappers of the tool (such as web applications) would have to account for this
+- Developers would have to deal with this when attempting to mix-and-match URLs
+  - this could be mitigated by applying `filters` before the column check, but
+    that might make the logic more complicated
+
+#### Option 2: include all columns in all rows
+
+When processing the CSVs, we could identify all columns that are present, and
+then ensure they are present with a blank value across all rows.
+
+Pros:
+
+- Wrappers of the tool (such as web applications) probably will have less to
+  deal with
+- Developers could more easily mix-and-match URLs
+
+Cons:
+
+- Ordering might be off at times?
+
+### What should we do with existing configurations?
+
+#### Option 1: do nothing
+
+Pros:
+
+- We'll be able to move away from the old properties faster
+
+Cons:
+
+- Developers will need to update their configurations
+- Wrappers of the tool (such as web applications) will need to ensure their
+  configurations are migrated
+
+#### Option 1: support mapping `filter_to_organisations` and `filter_to_urls` to `filters`
+
+Pros:
+
+- Developers won't need to immediately change their configurations
+
+Cons:
+
+- we will want to remove these eventually
+
+## Appendix

--- a/src/audit_manager.py
+++ b/src/audit_manager.py
@@ -4,13 +4,13 @@ import logging
 import os
 import time
 import urllib.parse
-from typing import Any
+from typing import Any, TypedDict
 
 import selenium
 from selenium.webdriver.common.by import By
 
 import src.filters
-from config import Config
+from config import Config, SiteData
 from src.analytics import Analytics
 from src.browser import Browser
 from src.output import CSVWriter
@@ -18,6 +18,11 @@ from src.output import CSVWriter
 # pylint: disable=too-many-statements
 
 logger = logging.getLogger('cwac')
+
+
+class AuditData(TypedDict):
+  audit_class: type[Any]
+  kwargs: dict[str, Any]
 
 
 class AuditManager:
@@ -31,7 +36,7 @@ class AuditManager:
     self.config = config
     self.browser = browser
     self.analytics = analytics
-    self.audits: dict[Any, dict[Any, Any]] = {}
+    self.audits: dict[str, AuditData] = {}
     self.filter = src.filters.URLFilter(self.config)
 
     # Stores URLs discarded as a key-value pair
@@ -39,7 +44,7 @@ class AuditManager:
     # if they are blocked by anti-bot measures.
     self.discarded_urls: dict[str, str] = {}
 
-  def register_audit(self, audit_name: str, audit_class: type[Any], **kwargs: Any) -> None:
+  def register_audit(self, audit_name: str, audit_class: type[Any], site_data: SiteData, **kwargs: Any) -> None:
     """Register audits to be run by run_audits().
 
     This can also be used to re-run a test with updated kwargs.
@@ -47,12 +52,13 @@ class AuditManager:
     Args:
         audit_name (str): Human-readable name for audit
         audit_class (Type[Any]): Reference to a class that runs the audit
+        site_data (SiteData): Data about the site being audited
         kwargs (Any): Arbitrary args to be passed to audit_class
     """
     # Register the audit (or update its kwargs)
     self.audits[audit_name] = {
       'audit_class': audit_class,
-      'kwargs': kwargs,
+      'kwargs': {**kwargs, 'site_data': site_data},
     }
 
   def test_for_anti_bot(self) -> str:

--- a/src/audit_manager.py
+++ b/src/audit_manager.py
@@ -21,7 +21,10 @@ logger = logging.getLogger('cwac')
 
 
 class AuditData(TypedDict):
+  """Data for running an audit."""
+
   audit_class: type[Any]
+  site_data: SiteData
   kwargs: dict[str, Any]
 
 
@@ -58,10 +61,11 @@ class AuditManager:
     # Register the audit (or update its kwargs)
     self.audits[audit_name] = {
       'audit_class': audit_class,
+      'site_data': site_data,
       'kwargs': {**kwargs, 'site_data': site_data},
     }
 
-  def test_for_anti_bot(self) -> str:
+  def test_for_anti_bot(self, site_data: SiteData) -> str:
     """Inspect the currently loaded page for anti-bot blocking.
 
     If bot blocking services such as Cloudflare, Incapsula, Azure Front Door,
@@ -127,9 +131,6 @@ class AuditManager:
       status = 'Azure Front Door'
 
     if status != 'Pass':
-      # Get the URL's organisation
-      org = self.config.lookup_organisation(url)
-
       # Get URL's netloc
       netloc = urllib.parse.urlparse(url).netloc
 
@@ -146,9 +147,9 @@ class AuditManager:
       csv_writer.append_rows(
         f'./results/{self.config.audit_name}/anti_bot.csv',
         {
-          'organisation': org['organisation'],
-          'domain': netloc,
+          **site_data['columns'],
           'url': url,
+          'domain': netloc,
           'anti_bot_check': status,
           'viewport_size': self.browser.viewport_size,
         },
@@ -257,7 +258,7 @@ class AuditManager:
         browser_status = self.browser.get(audit['kwargs']['url'])
 
         # Test for anti-bot measures
-        if self.test_for_anti_bot() != 'Pass':
+        if self.test_for_anti_bot(audit['site_data']) != 'Pass':
           # If URL is blocked, skip this URL
           logger.warning(
             'Skipping test %s on %s due to anti-bot',

--- a/src/audit_plugins/default_audit.py
+++ b/src/audit_plugins/default_audit.py
@@ -6,7 +6,7 @@ This plugin returns basic page information.
 import urllib.parse
 from typing import Any
 
-from config import Config
+from config import Config, SiteData
 from src.browser import Browser
 
 # Audit classes for use with AuditManager
@@ -32,7 +32,7 @@ class DefaultAudit:
     self.config = config
     self.browser = browser
     self.url = kwargs['url']
-    self.site_data = kwargs['site_data']
+    self.site_data: SiteData = kwargs['site_data']
     self.audit_id = kwargs['audit_id']
     self.page_id = kwargs['page_id']
 
@@ -48,8 +48,7 @@ class DefaultAudit:
       base_url = parsed_url.scheme + '://' + parsed_url.netloc
 
     return {
-      'organisation': self.site_data['organisation'],
-      'sector': self.site_data['sector'],
+      **self.site_data['columns'],
       'page_title': self.browser.driver.title,
       'base_url': base_url,
       'url': self.url,

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -574,10 +574,9 @@ class Crawler:
       csv_writer.append_rows(
         f'./results/{self.config.audit_name}/audit_log.csv',
         {
-          'organisation': site_data['organisation'],
+          **site_data['columns'],
           'base_url': site_data['url'],
           'url': url,
-          'sector': site_data['sector'],
         },
       )
 
@@ -649,10 +648,9 @@ class Crawler:
       csv_writer.append_rows(
         f'./results/{self.config.audit_name}/pages_scanned.csv',
         {
-          'organisation': site_data['organisation'],
+          **site_data['columns'],
           'base_url': site_data['url'],
           'number_of_pages': pages_scanned,
-          'sector': site_data['sector'],
         },
       )
 

--- a/src/output.py
+++ b/src/output.py
@@ -48,10 +48,16 @@ class CSVWriter:
     if not rows:
       return
 
-    keys = rows[0].keys()
+    keys = list(rows[0].keys())
 
     with self._get_file_lock(path):
       file_already_exists = os.path.exists(path)
+
+      # attempt to preserve the header order if the file already exists
+      if file_already_exists:
+        with open(path, encoding='utf-8-sig') as csvfile:
+          keys = list(csv.DictReader(csvfile).fieldnames or keys)
+
       with open(path, 'a', encoding='utf-8-sig') as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=keys)
         if not file_already_exists:

--- a/src/output.py
+++ b/src/output.py
@@ -53,7 +53,7 @@ class CSVWriter:
     with self._get_file_lock(path):
       try:
         # attempt to preserve the header order if the file already exists
-        with open(path, encoding='utf-8-sig') as csvfile:
+        with open(path, encoding='utf-8-sig', newline='') as csvfile:
           keys = csv.DictReader(csvfile).fieldnames
       except FileNotFoundError:
         write_header = True
@@ -62,7 +62,7 @@ class CSVWriter:
         keys = list(rows[0].keys())
         write_header = True
 
-      with open(path, 'a', encoding='utf-8-sig') as csvfile:
+      with open(path, 'a', encoding='utf-8-sig', newline='') as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=keys)
         if write_header:
           writer.writeheader()

--- a/src/output.py
+++ b/src/output.py
@@ -233,8 +233,8 @@ def generate_axe_core_template_aware_results(audit_name: str) -> None:
   # We want to present the most repeated (and therefore likely template-wide)
   # issues first, as these are the most critical to address.
   data_frame = data_frame.sort_values(
-    by=['num_issues', 'organisation', 'base_url', 'url'],
-    ascending=[False, True, True, True],
+    by=['num_issues', 'base_url', 'url'],
+    ascending=[False, True, True],
   )
 
   # Write the aggregated results to CSV file, preserving the prepared column order

--- a/src/output.py
+++ b/src/output.py
@@ -60,6 +60,7 @@ class CSVWriter:
 
       if keys is None:
         keys = list(rows[0].keys())
+        write_header = True
 
       with open(path, 'a', encoding='utf-8-sig') as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=keys)

--- a/src/output.py
+++ b/src/output.py
@@ -2,7 +2,6 @@
 
 import csv
 import logging
-import os
 import threading
 import time
 from typing import Any, ClassVar
@@ -48,19 +47,23 @@ class CSVWriter:
     if not rows:
       return
 
-    keys = list(rows[0].keys())
+    keys = None
+    write_header = False
 
     with self._get_file_lock(path):
-      file_already_exists = os.path.exists(path)
-
-      # attempt to preserve the header order if the file already exists
-      if file_already_exists:
+      try:
+        # attempt to preserve the header order if the file already exists
         with open(path, encoding='utf-8-sig') as csvfile:
-          keys = list(csv.DictReader(csvfile).fieldnames or keys)
+          keys = csv.DictReader(csvfile).fieldnames
+      except FileNotFoundError:
+        write_header = True
+
+      if keys is None:
+        keys = list(rows[0].keys())
 
       with open(path, 'a', encoding='utf-8-sig') as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=keys)
-        if not file_already_exists:
+        if write_header:
           writer.writeheader()
         writer.writerows(rows)
 

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -9,15 +9,14 @@ cd "${PROJECT_ROOT}"
 
 # create a url file
 cat <<URLS > base_urls/visit/e2e.csv
-organisation,url,sector
-e2e,https://example.com,e2e
+url,sector
+https://example.com,e2e
 URLS
 
 # create a config file
 cat config/config_default.json | jq '
   .audit_name = "e2e" |
   .max_links_per_domain = 3 |
-  .filter_to_organisations = ["e2e"] |
   .filter_to_urls = ["example.com"] |
   .audit_plugins |= map_values(.enabled = true)
 ' > config/config_e2e.json

--- a/tests/test_audit_manager.py
+++ b/tests/test_audit_manager.py
@@ -4,7 +4,20 @@ from unittest.mock import MagicMock
 
 from pytest_mock import MockerFixture
 
+from config import SiteData
 from src.audit_manager import AuditManager
+
+site_data: SiteData = {
+  'url': 'https://bnl.com/',
+  'supports_head': True,
+  'columns': {
+    'organisation': "Buy 'n' Large",
+    'url': 'https://bnl.com/',
+    'sector': 'Sales',
+    'region': 'Overseas',
+    'priority': 'Medium',
+  },
+}
 
 
 class SuccessfulAudit:
@@ -46,8 +59,8 @@ def test_run_audits_returns_true_when_anti_bot_happens_after_a_success(
   """Returns True when anti-bot blocking happens after an earlier audit succeeded."""
   manager = make_audit_manager(mocker)
 
-  manager.register_audit('first', SuccessfulAudit, url='https://example.govt.nz/ok')
-  manager.register_audit('second', SuccessfulAudit, url='https://example.govt.nz/blocked')
+  manager.register_audit('first', SuccessfulAudit, url='https://example.govt.nz/ok', site_data=site_data)
+  manager.register_audit('second', SuccessfulAudit, url='https://example.govt.nz/blocked', site_data=site_data)
 
   mocker.patch.object(manager, 'test_for_anti_bot', side_effect=['Pass', 'Cloudflare'])
 
@@ -60,7 +73,7 @@ def test_run_audits_returns_false_when_anti_bot_happens_before_any_success(
   """Returns False when anti-bot blocking happens before any audit succeeded."""
   manager = make_audit_manager(mocker)
 
-  manager.register_audit('first', SuccessfulAudit, url='https://example.govt.nz/blocked')
+  manager.register_audit('first', SuccessfulAudit, url='https://example.govt.nz/blocked', site_data=site_data)
 
   mocker.patch.object(manager, 'test_for_anti_bot', return_value='Cloudflare')
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -328,3 +328,213 @@ class TestUrlLoading:
       'https://stark.com/finance',
       'https://stark.com/rd',
     ]
+
+  def test_urls_have_the_same_columns(self, fs: FakeFilesystem) -> None:
+    """Adds the same columns to all urls, to avoid csv writer errors."""
+    fs.add_real_file('config/config_default.json')
+
+    with open('base_urls/visit/my urls.csv', 'w', encoding='utf-8') as f:
+      f.write(
+        textwrap.dedent("""
+          organisation,url,sector,priority
+          ACME,https://acme.com/finance,Finance,High
+          ACME,https://acme.com/hr,Human Resources,Medium
+          ACME,https://acme.com/legal,Legal,Low
+          Stark Industries,https://stark.com/rd,R&D,High
+          Stark Industries,https://stark.com/finance,Finance,Medium
+        """).strip(),
+      )
+    with open('base_urls/visit/q3_2024_urls.csv', 'w', encoding='utf-8') as f:
+      f.write(
+        textwrap.dedent("""
+          url,sector,region,priority
+          https://wayne.com/security,Security,Wellington,High
+          https://wayne.com/finance,Finance,Auckland,Medium
+          https://wayne.com/legal,Legal,Wellington,Low
+          https://cyberdyne.com/rd,R&D,Auckland,High
+          https://cyberdyne.com/security,Security,Wellington,Medium
+        """).strip(),
+      )
+    with open('base_urls/visit/theirs_urls.csv', 'w', encoding='utf-8') as f:
+      f.write(
+        textwrap.dedent("""
+          url
+          https://umbrella.com
+          https://bnl.com/
+          https://umbrella.com/hr
+          https://umbrella.com/legal
+          https://bnl.com/finance
+        """).strip(),
+      )
+
+    config = Config('config_default.json')
+
+    expected: list[SiteData] = [
+      {
+        'url': 'https://acme.com/finance',
+        'supports_head': True,
+        'columns': {
+          'organisation': 'ACME',
+          'url': 'https://acme.com/finance',
+          'sector': 'Finance',
+          'priority': 'High',
+          'region': '',
+        },
+      },
+      {
+        'url': 'https://acme.com/hr',
+        'supports_head': True,
+        'columns': {
+          'organisation': 'ACME',
+          'url': 'https://acme.com/hr',
+          'sector': 'Human Resources',
+          'priority': 'Medium',
+          'region': '',
+        },
+      },
+      {
+        'url': 'https://acme.com/legal',
+        'supports_head': True,
+        'columns': {
+          'organisation': 'ACME',
+          'url': 'https://acme.com/legal',
+          'sector': 'Legal',
+          'priority': 'Low',
+          'region': '',
+        },
+      },
+      {
+        'url': 'https://bnl.com/',
+        'supports_head': True,
+        'columns': {
+          'url': 'https://bnl.com/',
+          'organisation': '',
+          'priority': '',
+          'region': '',
+          'sector': '',
+        },
+      },
+      {
+        'url': 'https://bnl.com/finance',
+        'supports_head': True,
+        'columns': {
+          'url': 'https://bnl.com/finance',
+          'organisation': '',
+          'priority': '',
+          'region': '',
+          'sector': '',
+        },
+      },
+      {
+        'url': 'https://cyberdyne.com/rd',
+        'supports_head': True,
+        'columns': {
+          'url': 'https://cyberdyne.com/rd',
+          'sector': 'R&D',
+          'region': 'Auckland',
+          'priority': 'High',
+          'organisation': '',
+        },
+      },
+      {
+        'url': 'https://cyberdyne.com/security',
+        'supports_head': True,
+        'columns': {
+          'url': 'https://cyberdyne.com/security',
+          'sector': 'Security',
+          'region': 'Wellington',
+          'priority': 'Medium',
+          'organisation': '',
+        },
+      },
+      {
+        'url': 'https://stark.com/finance',
+        'supports_head': True,
+        'columns': {
+          'organisation': 'Stark Industries',
+          'url': 'https://stark.com/finance',
+          'sector': 'Finance',
+          'priority': 'Medium',
+          'region': '',
+        },
+      },
+      {
+        'url': 'https://stark.com/rd',
+        'supports_head': True,
+        'columns': {
+          'organisation': 'Stark Industries',
+          'url': 'https://stark.com/rd',
+          'sector': 'R&D',
+          'priority': 'High',
+          'region': '',
+        },
+      },
+      {
+        'url': 'https://umbrella.com',
+        'supports_head': True,
+        'columns': {
+          'url': 'https://umbrella.com',
+          'organisation': '',
+          'priority': '',
+          'region': '',
+          'sector': '',
+        },
+      },
+      {
+        'url': 'https://umbrella.com/hr',
+        'supports_head': True,
+        'columns': {
+          'url': 'https://umbrella.com/hr',
+          'organisation': '',
+          'priority': '',
+          'region': '',
+          'sector': '',
+        },
+      },
+      {
+        'url': 'https://umbrella.com/legal',
+        'supports_head': True,
+        'columns': {
+          'url': 'https://umbrella.com/legal',
+          'organisation': '',
+          'priority': '',
+          'region': '',
+          'sector': '',
+        },
+      },
+      {
+        'url': 'https://wayne.com/finance',
+        'supports_head': True,
+        'columns': {
+          'url': 'https://wayne.com/finance',
+          'sector': 'Finance',
+          'region': 'Auckland',
+          'priority': 'Medium',
+          'organisation': '',
+        },
+      },
+      {
+        'url': 'https://wayne.com/legal',
+        'supports_head': True,
+        'columns': {
+          'url': 'https://wayne.com/legal',
+          'sector': 'Legal',
+          'region': 'Wellington',
+          'priority': 'Low',
+          'organisation': '',
+        },
+      },
+      {
+        'url': 'https://wayne.com/security',
+        'supports_head': True,
+        'columns': {
+          'url': 'https://wayne.com/security',
+          'sector': 'Security',
+          'region': 'Wellington',
+          'priority': 'High',
+          'organisation': '',
+        },
+      },
+    ]
+
+    assert sorted(config.audit_subjects, key=lambda site: site['url']) == expected

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -539,6 +539,24 @@ class TestUrlLoading:
 
     assert sorted(config.audit_subjects, key=lambda site: site['url']) == expected
 
+  def test_raises_on_csv_missing_url_column(self, fs: FakeFilesystem) -> None:
+    """Raises a helpful error when a csv does not have the required "url" column."""
+    fs.add_real_file('config/config_default.json')
+
+    fs.create_file(
+      'base_urls/visit/bad.csv',
+      contents=textwrap.dedent("""
+        organisation,sector,region,priority
+        ACME,Human Resources,Wellington,High
+        ACME,Legal,Auckland,Low
+      """).strip(),
+    )
+
+    with pytest.raises(ValueError) as err:
+      Config('config_default.json')
+
+    assert str(err.value) == 'bad.csv does not have the required "url" column'
+
   def test_raises_on_csv_missing_columns(self, fs: FakeFilesystem) -> None:
     """Raises a helpful error when a csv has a row with missing columns."""
     fs.add_real_file('config/config_default.json')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -538,3 +538,45 @@ class TestUrlLoading:
     ]
 
     assert sorted(config.audit_subjects, key=lambda site: site['url']) == expected
+
+  def test_raises_on_csv_missing_columns(self, fs: FakeFilesystem) -> None:
+    """Raises a helpful error when a csv has a row with missing columns."""
+    fs.add_real_file('config/config_default.json')
+
+    fs.create_file(
+      'base_urls/visit/bad.csv',
+      contents=textwrap.dedent("""
+        organisation,url,sector,region,priority
+        ACME,https://acme.com/humans,Human Resources,Wellington,High
+        ACME,https://acme.com/consult,Legal,Auckland
+      """).strip(),
+    )
+
+    with pytest.raises(ValueError) as err:
+      Config('config_default.json')
+
+    assert (
+      str(err.value)
+      == "bad.csv has a row whose columns don't match the headers: ['ACME', 'https://acme.com/consult', 'Legal', 'Auckland']"
+    )
+
+  def test_raises_on_csv_extra_columns(self, fs: FakeFilesystem) -> None:
+    """Raises a helpful error when a csv has a row with extra columns."""
+    fs.add_real_file('config/config_default.json')
+
+    fs.create_file(
+      'base_urls/visit/bad.csv',
+      contents=textwrap.dedent("""
+        organisation,url,sector,region,priority
+        ACME,https://acme.com/humans,Human Resources,Wellington,High
+        ACME,https://acme.com/consult,Legal,Auckland,Low,External
+      """).strip(),
+    )
+
+    with pytest.raises(ValueError) as err:
+      Config('config_default.json')
+
+    assert (
+      str(err.value)
+      == "bad.csv has a row whose columns don't match the headers: ['ACME', 'https://acme.com/consult', 'Legal', 'Auckland', 'Low', 'External']"
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -575,7 +575,7 @@ class TestUrlLoading:
 
     assert (
       str(err.value)
-      == "bad.csv has a row whose columns don't match the headers: ['ACME', 'https://acme.com/consult', 'Legal', 'Auckland']"
+      == "bad.csv has a row whose columns don't match the headers: ['ACME', 'https://acme.com/consult', 'Legal', 'Auckland']"  # noqa: E501 RUF100
     )
 
   def test_raises_on_csv_extra_columns(self, fs: FakeFilesystem) -> None:
@@ -596,5 +596,5 @@ class TestUrlLoading:
 
     assert (
       str(err.value)
-      == "bad.csv has a row whose columns don't match the headers: ['ACME', 'https://acme.com/consult', 'Legal', 'Auckland', 'Low', 'External']"
+      == "bad.csv has a row whose columns don't match the headers: ['ACME', 'https://acme.com/consult', 'Legal', 'Auckland', 'Low', 'External']"  # noqa: E501 RUF100
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -194,7 +194,6 @@ class TestUrlLoading:
     expected: list[SiteData] = [
       {
         'url': 'https://bnl.com/',
-        'sector': 'Sales',
         'supports_head': True,
         'columns': {
           'organisation': "Buy 'n' Large",
@@ -206,7 +205,6 @@ class TestUrlLoading:
       },
       {
         'url': 'https://bnl.com/finance',
-        'sector': 'Finance',
         'supports_head': True,
         'columns': {
           'organisation': "Buy 'n' Large",
@@ -218,7 +216,6 @@ class TestUrlLoading:
       },
       {
         'url': 'https://cyberdyne.com/rd',
-        'sector': 'R&D',
         'supports_head': True,
         'columns': {
           'organisation': 'Cyberdyne Systems',
@@ -230,7 +227,6 @@ class TestUrlLoading:
       },
       {
         'url': 'https://cyberdyne.com/security',
-        'sector': 'Security',
         'supports_head': True,
         'columns': {
           'organisation': 'Cyberdyne Systems',
@@ -242,7 +238,6 @@ class TestUrlLoading:
       },
       {
         'url': 'https://umbrella.com',
-        'sector': 'R&D',
         'supports_head': True,
         'columns': {
           'organisation': 'Umbrella Corp',
@@ -254,7 +249,6 @@ class TestUrlLoading:
       },
       {
         'url': 'https://umbrella.com/hr',
-        'sector': 'Human Resources',
         'supports_head': True,
         'columns': {
           'organisation': 'Umbrella Corp',
@@ -266,7 +260,6 @@ class TestUrlLoading:
       },
       {
         'url': 'https://umbrella.com/legal',
-        'sector': 'Legal',
         'supports_head': True,
         'columns': {
           'organisation': 'Umbrella Corp',
@@ -278,7 +271,6 @@ class TestUrlLoading:
       },
       {
         'url': 'https://wayne.com/finance',
-        'sector': 'Finance',
         'supports_head': True,
         'columns': {
           'organisation': 'Wayne Enterprises',
@@ -290,7 +282,6 @@ class TestUrlLoading:
       },
       {
         'url': 'https://wayne.com/legal',
-        'sector': 'Legal',
         'supports_head': True,
         'columns': {
           'organisation': 'Wayne Enterprises',
@@ -302,7 +293,6 @@ class TestUrlLoading:
       },
       {
         'url': 'https://wayne.com/security',
-        'sector': 'Security',
         'supports_head': True,
         'columns': {
           'organisation': 'Wayne Enterprises',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -539,8 +539,8 @@ class TestUrlLoading:
 
     assert sorted(config.audit_subjects, key=lambda site: site['url']) == expected
 
-  def test_raises_on_csv_missing_url_column(self, fs: FakeFilesystem) -> None:
-    """Raises a helpful error when a csv does not have the required "url" column."""
+  def test_raises_on_csv_missing_url_header(self, fs: FakeFilesystem) -> None:
+    """Raises a helpful error when a csv does not have the required "url" header."""
     fs.add_real_file('config/config_default.json')
 
     fs.create_file(
@@ -555,7 +555,25 @@ class TestUrlLoading:
     with pytest.raises(ValueError) as err:
       Config('config_default.json')
 
-    assert str(err.value) == 'bad.csv does not have the required "url" column'
+    assert str(err.value) == 'bad.csv does not have the required "url" header'
+
+  def test_raises_on_csv_blank_url_column(self, fs: FakeFilesystem) -> None:
+    """Raises a helpful error when a csv has a row whose "url" column is blank."""
+    fs.add_real_file('config/config_default.json')
+
+    fs.create_file(
+      'base_urls/visit/bad.csv',
+      contents=textwrap.dedent("""
+        organisation,url,sector,region,priority
+        ACME,https://acme.com/humans,Human Resources,Wellington,High
+        ACME,,Legal,Auckland,Low
+      """).strip(),
+    )
+
+    with pytest.raises(ValueError) as err:
+      Config('config_default.json')
+
+    assert str(err.value) == "bad.csv has a row whose \"url\" column is blank: ['ACME', '', 'Legal', 'Auckland', 'Low']"
 
   def test_raises_on_csv_missing_columns(self, fs: FakeFilesystem) -> None:
     """Raises a helpful error when a csv has a row with missing columns."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@
 
 import json
 import platform
+import textwrap
 
 import pytest
 from pyfakefs.fake_filesystem import FakeFilesystem
@@ -139,3 +140,209 @@ class TestChromeLocationsAutoResolution:
 
     assert config.chrome_binary_location == '/home/user/.cache/selenium/chrome/linux64/139.0.7258.68'
     assert config.chrome_driver_location == '/home/user/.cache/selenium/chromedriver/linux64/139.0.7258.68'
+
+
+class TestUrlLoading:
+  """Tests the loading of urls from csv files."""
+
+  @pytest.fixture(autouse=True)
+  def setup_base_urls_csvs(self, fs: FakeFilesystem) -> None:
+    """Set up some csvs with urls and various columns."""
+    fs.create_file(
+      'base_urls/visit/my urls.csv',
+      contents=textwrap.dedent("""
+        organisation,url,sector,region,priority
+        ACME,https://acme.com/finance,Finance,Wellington,High
+        ACME,https://acme.com/hr,Human Resources,Wellington,Medium
+        ACME,https://acme.com/legal,Legal,Auckland,Low
+        Stark Industries,https://stark.com/rd,R&D,Auckland,High
+        Stark Industries,https://stark.com/finance,Finance,Overseas,Medium
+      """).strip(),
+    )
+    fs.create_file(
+      'base_urls/visit/q3_2024_urls.csv',
+      contents=textwrap.dedent("""
+        organisation,url,sector,region,priority
+        Wayne Enterprises,https://wayne.com/security,Security,Wellington,High
+        Wayne Enterprises,https://wayne.com/finance,Finance,Auckland,Medium
+        Wayne Enterprises,https://wayne.com/legal,Legal,Wellington,Low
+        Cyberdyne Systems,https://cyberdyne.com/rd,R&D,Auckland,High
+        Cyberdyne Systems,https://cyberdyne.com/security,Security,Wellington,Medium
+      """).strip(),
+    )
+    fs.create_file(
+      'base_urls/visit/theirs_urls.csv',
+      contents=textwrap.dedent("""
+        organisation,url,sector,region,priority
+        Umbrella Corp,https://umbrella.com,R&D,Overseas,High
+        Buy 'n' Large,https://bnl.com/,Sales,Overseas,Medium
+        Umbrella Corp,https://umbrella.com/hr,Human Resources,Overseas,Low
+        Umbrella Corp,https://umbrella.com/legal,Legal,Wellington,Medium
+        Buy 'n' Large,https://bnl.com/finance,Finance,Auckland,High
+      """).strip(),
+    )
+
+  def test_urls_are_loaded(self, fs: FakeFilesystem) -> None:
+    """Loads urls from csv files."""
+    fs.add_real_file('config/config_default.json')
+
+    # remove a csv to reduce the amount of sites we have to list
+    fs.remove('base_urls/visit/my urls.csv')
+
+    config = Config('config_default.json')
+
+    assert sorted(config.audit_subjects, key=lambda site: site['url']) == [
+      {
+        'organisation': "Buy 'n' Large",
+        'url': 'https://bnl.com/',
+        'sector': 'Sales',
+        'supports_head': True,
+        'columns': {
+          'organisation': "Buy 'n' Large",
+          'url': 'https://bnl.com/',
+          'sector': 'Sales',
+          'region': 'Overseas',
+          'priority': 'Medium',
+        },
+      },
+      {
+        'organisation': "Buy 'n' Large",
+        'url': 'https://bnl.com/finance',
+        'sector': 'Finance',
+        'supports_head': True,
+        'columns': {
+          'organisation': "Buy 'n' Large",
+          'url': 'https://bnl.com/finance',
+          'sector': 'Finance',
+          'region': 'Auckland',
+          'priority': 'High',
+        },
+      },
+      {
+        'organisation': 'Cyberdyne Systems',
+        'url': 'https://cyberdyne.com/rd',
+        'sector': 'R&D',
+        'supports_head': True,
+        'columns': {
+          'organisation': 'Cyberdyne Systems',
+          'url': 'https://cyberdyne.com/rd',
+          'sector': 'R&D',
+          'region': 'Auckland',
+          'priority': 'High',
+        },
+      },
+      {
+        'organisation': 'Cyberdyne Systems',
+        'url': 'https://cyberdyne.com/security',
+        'sector': 'Security',
+        'supports_head': True,
+        'columns': {
+          'organisation': 'Cyberdyne Systems',
+          'url': 'https://cyberdyne.com/security',
+          'sector': 'Security',
+          'region': 'Wellington',
+          'priority': 'Medium',
+        },
+      },
+      {
+        'organisation': 'Umbrella Corp',
+        'url': 'https://umbrella.com',
+        'sector': 'R&D',
+        'supports_head': True,
+        'columns': {
+          'organisation': 'Umbrella Corp',
+          'url': 'https://umbrella.com',
+          'sector': 'R&D',
+          'region': 'Overseas',
+          'priority': 'High',
+        },
+      },
+      {
+        'organisation': 'Umbrella Corp',
+        'url': 'https://umbrella.com/hr',
+        'sector': 'Human Resources',
+        'supports_head': True,
+        'columns': {
+          'organisation': 'Umbrella Corp',
+          'url': 'https://umbrella.com/hr',
+          'sector': 'Human Resources',
+          'region': 'Overseas',
+          'priority': 'Low',
+        },
+      },
+      {
+        'organisation': 'Umbrella Corp',
+        'url': 'https://umbrella.com/legal',
+        'sector': 'Legal',
+        'supports_head': True,
+        'columns': {
+          'organisation': 'Umbrella Corp',
+          'url': 'https://umbrella.com/legal',
+          'sector': 'Legal',
+          'region': 'Wellington',
+          'priority': 'Medium',
+        },
+      },
+      {
+        'organisation': 'Wayne Enterprises',
+        'url': 'https://wayne.com/finance',
+        'sector': 'Finance',
+        'supports_head': True,
+        'columns': {
+          'organisation': 'Wayne Enterprises',
+          'url': 'https://wayne.com/finance',
+          'sector': 'Finance',
+          'region': 'Auckland',
+          'priority': 'Medium',
+        },
+      },
+      {
+        'organisation': 'Wayne Enterprises',
+        'url': 'https://wayne.com/legal',
+        'sector': 'Legal',
+        'supports_head': True,
+        'columns': {
+          'organisation': 'Wayne Enterprises',
+          'url': 'https://wayne.com/legal',
+          'sector': 'Legal',
+          'region': 'Wellington',
+          'priority': 'Low',
+        },
+      },
+      {
+        'organisation': 'Wayne Enterprises',
+        'url': 'https://wayne.com/security',
+        'sector': 'Security',
+        'supports_head': True,
+        'columns': {
+          'organisation': 'Wayne Enterprises',
+          'url': 'https://wayne.com/security',
+          'sector': 'Security',
+          'region': 'Wellington',
+          'priority': 'High',
+        },
+      },
+    ]
+
+  def test_urls_are_loaded_from_set_path(self, fs: FakeFilesystem) -> None:
+    """Loads urls from csv files within a directory pointed to by config."""
+    fs.add_real_file('config/config_default.json', read_only=False)
+
+    with open('config/config_default.json', 'r+', encoding='utf-8') as f:
+      c = {**json.load(f), 'base_urls_visit_path': './base_urls/alternative/'}
+      f.seek(0)
+      json.dump(c, f)
+      f.truncate()
+
+    fs.makedirs('base_urls/alternative')
+    fs.rename('base_urls/visit/my urls.csv', 'base_urls/alternative/my urls.csv')
+
+    config = Config('config_default.json')
+
+    assert sorted([site['url'] for site in config.audit_subjects]) == [
+      'https://acme.com/finance',
+      'https://acme.com/hr',
+      'https://acme.com/legal',
+      'https://stark.com/finance',
+      'https://stark.com/rd',
+    ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,7 +8,7 @@ import pytest
 from pyfakefs.fake_filesystem import FakeFilesystem
 from pytest_mock import MockerFixture
 
-from config import Config
+from config import Config, SiteData
 
 
 @pytest.fixture(autouse=True)
@@ -191,9 +191,8 @@ class TestUrlLoading:
 
     config = Config('config_default.json')
 
-    assert sorted(config.audit_subjects, key=lambda site: site['url']) == [
+    expected: list[SiteData] = [
       {
-        'organisation': "Buy 'n' Large",
         'url': 'https://bnl.com/',
         'sector': 'Sales',
         'supports_head': True,
@@ -206,7 +205,6 @@ class TestUrlLoading:
         },
       },
       {
-        'organisation': "Buy 'n' Large",
         'url': 'https://bnl.com/finance',
         'sector': 'Finance',
         'supports_head': True,
@@ -219,7 +217,6 @@ class TestUrlLoading:
         },
       },
       {
-        'organisation': 'Cyberdyne Systems',
         'url': 'https://cyberdyne.com/rd',
         'sector': 'R&D',
         'supports_head': True,
@@ -232,7 +229,6 @@ class TestUrlLoading:
         },
       },
       {
-        'organisation': 'Cyberdyne Systems',
         'url': 'https://cyberdyne.com/security',
         'sector': 'Security',
         'supports_head': True,
@@ -245,7 +241,6 @@ class TestUrlLoading:
         },
       },
       {
-        'organisation': 'Umbrella Corp',
         'url': 'https://umbrella.com',
         'sector': 'R&D',
         'supports_head': True,
@@ -258,7 +253,6 @@ class TestUrlLoading:
         },
       },
       {
-        'organisation': 'Umbrella Corp',
         'url': 'https://umbrella.com/hr',
         'sector': 'Human Resources',
         'supports_head': True,
@@ -271,7 +265,6 @@ class TestUrlLoading:
         },
       },
       {
-        'organisation': 'Umbrella Corp',
         'url': 'https://umbrella.com/legal',
         'sector': 'Legal',
         'supports_head': True,
@@ -284,7 +277,6 @@ class TestUrlLoading:
         },
       },
       {
-        'organisation': 'Wayne Enterprises',
         'url': 'https://wayne.com/finance',
         'sector': 'Finance',
         'supports_head': True,
@@ -297,7 +289,6 @@ class TestUrlLoading:
         },
       },
       {
-        'organisation': 'Wayne Enterprises',
         'url': 'https://wayne.com/legal',
         'sector': 'Legal',
         'supports_head': True,
@@ -310,7 +301,6 @@ class TestUrlLoading:
         },
       },
       {
-        'organisation': 'Wayne Enterprises',
         'url': 'https://wayne.com/security',
         'sector': 'Security',
         'supports_head': True,
@@ -323,6 +313,8 @@ class TestUrlLoading:
         },
       },
     ]
+
+    assert sorted(config.audit_subjects, key=lambda site: site['url']) == expected
 
   def test_urls_are_loaded_from_set_path(self, fs: FakeFilesystem) -> None:
     """Loads urls from csv files within a directory pointed to by config."""

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -93,6 +93,36 @@ class TestCSVWriter:
     with open('file.csv', encoding='utf-8-sig') as f:
       assert f.read() == textwrap.dedent(expected).lstrip()
 
+  def test_appends_to_empty_file(self) -> None:
+    """Writes new rows to an empty csv file, without duplicating the header."""
+    with open('file.csv', 'w', encoding='utf-8-sig') as f:
+      f.write('')
+
+    writer = CSVWriter()
+
+    writer.append_rows(
+      'file.csv',
+      {'name': 'Bob', 'age': 20, 'location': 'Wellington'},
+    )
+
+    assert os.path.exists('file.csv') is True
+
+    writer.append_rows(
+      'file.csv',
+      {'name': 'Alice', 'age': 31, 'location': 'Wellington'},
+      {'name': 'Greg', 'age': 23, 'location': 'Auckland'},
+    )
+
+    expected = """
+      name,age,location
+      Bob,20,Wellington
+      Alice,31,Wellington
+      Greg,23,Auckland
+    """
+
+    with open('file.csv', encoding='utf-8-sig') as f:
+      assert f.read() == textwrap.dedent(expected).lstrip()
+
   def test_ignores_missing_columns(self) -> None:
     """Ignores columns missing in subsequent rows."""
     writer = CSVWriter()

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -116,6 +116,33 @@ class TestCSVWriter:
     with open('file.csv', encoding='utf-8-sig') as f:
       assert f.read() == textwrap.dedent(expected).lstrip()
 
+  def test_ignores_missing_columns_across_writes(self) -> None:
+    """Ignores columns missing in subsequent rows across multiple writes."""
+    writer = CSVWriter()
+
+    writer.append_rows(
+      'file.csv',
+      {'name': 'Bob', 'age': 20, 'location': 'Wellington'},
+      {'name': 'Alice', 'age': 31},
+    )
+
+    assert os.path.exists('file.csv') is True
+
+    writer.append_rows(
+      'file.csv',
+      {'age': 23, 'location': 'Auckland'},
+    )
+
+    expected = """
+      name,age,location
+      Bob,20,Wellington
+      Alice,31,
+      ,23,Auckland
+    """
+
+    with open('file.csv', encoding='utf-8-sig') as f:
+      assert f.read() == textwrap.dedent(expected).lstrip()
+
   def test_raises_extra_columns(self) -> None:
     """Errors when rows have extra columns."""
     writer = CSVWriter()
@@ -143,6 +170,33 @@ class TestCSVWriter:
     )
 
     assert os.path.exists('file.csv') is True
+
+    expected = """
+      name,age,location
+      Bob,20,Wellington
+      Alice,31,Wellington
+      Greg,23,Auckland
+    """
+
+    with open('file.csv', encoding='utf-8-sig') as f:
+      assert f.read() == textwrap.dedent(expected).lstrip()
+
+  def test_preserves_column_order(self) -> None:
+    """Preserves column order when writing to an existing file."""
+    writer = CSVWriter()
+
+    writer.append_rows(
+      'file.csv',
+      {'name': 'Bob', 'age': 20, 'location': 'Wellington'},
+      {'age': 31, 'name': 'Alice', 'location': 'Wellington'},
+    )
+
+    assert os.path.exists('file.csv') is True
+
+    writer.append_rows(
+      'file.csv',
+      {'location': 'Auckland', 'age': 23, 'name': 'Greg'},
+    )
 
     expected = """
       name,age,location


### PR DESCRIPTION
This removes the requirement for URLs to have the arbitrary `organisation` and `sector` columns since they're not necessarily relevant to everyone.

Instead, we now only require the `url` column, and any additional columns are included in the output csvs which preserves the output for those that do want those columns, but enables more flexibility