### PR TITLE
fix: error if CSVs have a different number of columns than headers

### DIFF
--- a/config.py
+++ b/config.py
@@ -171,7 +171,7 @@ class Config:
           reader = csv.reader(file)
           header = next(reader)
           for row in reader:
-            dict_row = cast(dict[str, str], dict(zip(header, row)))
+            dict_row = cast(dict[str, str], dict(zip(header, row, strict=True)))
 
             # Strip whitespace from URL
             dict_row['url'] = dict_row['url'].strip()
@@ -243,7 +243,7 @@ class Config:
                 filename,
               )
 
-            subject = cast(SiteData, dict(zip(header, row)))
+            subject = cast(SiteData, dict(zip(header, row, strict=True)))
 
             # Parse the URL to get just the domain
             parsed_url = parse.urlparse(subject['url'])

--- a/ruff.toml
+++ b/ruff.toml
@@ -12,6 +12,7 @@ ignore = [
 ]
 extend-select = [
   'A',
+  'B',    # flake8-bugbear
   'D',    # pydocstyle
   'E',    # pycodestyle
   'EXE',


### PR DESCRIPTION
This is only actually possible for `nohead` CSVs as right now we enforce `visit` CSVs only have three columns, but in practice I would be very surprised if it actually causes any issues