### PR TITLE
refactor: remove redundant "mode" when opening files and enable `UP` rules

### DIFF
--- a/config.py
+++ b/config.py
@@ -69,7 +69,7 @@ class Config:
 
   def __init__(self, config_filename: str) -> None:
     """Read config.json into self.config."""
-    with open('./config/' + config_filename, 'r', encoding='utf-8-sig') as file:
+    with open('./config/' + config_filename, encoding='utf-8-sig') as file:
       self.config: dict[str, Any] = json.load(file)
 
     self.unique_id = 0
@@ -307,7 +307,7 @@ class Config:
         )
 
   def __determine_chrome_version(self) -> str:
-    with open('package.json', 'r', encoding='utf-8-sig') as file:
+    with open('package.json', encoding='utf-8-sig') as file:
       package_json = json.load(file)
 
       return str(package_json['config']['chromeVersion'])
@@ -359,7 +359,7 @@ class Config:
         raise ValueError('config_filename must be alphanumeric, underscores, and hyphens')
     else:
       config_filename = 'config_default.json'
-    with open('./config/' + config_filename, 'r', encoding='utf-8-sig') as file:
+    with open('./config/' + config_filename, encoding='utf-8-sig') as file:
       # Write the config file to the results folder
       return json.load(file)
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -27,6 +27,7 @@ extend-select = [
   'PLW',  # pylint warnings
   'S',    # flake8-bandit
   'SIM',  # flake8-simplify
+  'UP',   # pyupgrade
   'W'     # pycodestyle
 ]
 

--- a/src/audit_plugins/language_audit.py
+++ b/src/audit_plugins/language_audit.py
@@ -153,11 +153,11 @@ class LanguageAudit(DefaultAudit):
     """
     # Read Readability.js
     path_1 = './node_modules/@mozilla/readability/Readability.js'
-    with open(path_1, 'r', encoding='utf-8-sig') as file:
+    with open(path_1, encoding='utf-8-sig') as file:
       readability_js = file.read()
 
     path_2 = './node_modules/@mozilla/readability/Readability-readerable.js'
-    with open(path_2, 'r', encoding='utf-8-sig') as file:
+    with open(path_2, encoding='utf-8-sig') as file:
       readability_js += file.read()
 
     # JavaScript to execute Readability

--- a/src/output.py
+++ b/src/output.py
@@ -53,7 +53,7 @@ class CSVWriter:
     Returns:
         list[dict[Any, Any]]: list of dictionaries
     """
-    with self.get_file_lock(path), open(path, 'r', encoding='utf-8-sig') as csvfile:
+    with self.get_file_lock(path), open(path, encoding='utf-8-sig') as csvfile:
       reader = csv.DictReader(csvfile)
       rows = list(reader)
     return rows


### PR DESCRIPTION
This enables the `UP` rules and addresses the [violations of UP015](https://docs.astral.sh/ruff/rules/redundant-open-modes/), which is the only rule of that set which we have violations for