### PR TITLE
feat(config): max_links_per_domain 0 means scan all pages within scope

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -17,9 +17,9 @@
       "type": "boolean"
     },
     "max_links_per_domain": {
-      "description": "Maximum number of pages to crawl per domain. Set to 1 to audit only the base URL",
+      "description": "Maximum number of pages to crawl per domain. Set to 1 to audit only the base URL, or 0 to scan all pages within scope",
       "type": "integer",
-      "minimum": 1
+      "minimum": 0
     },
     "thread_count": {
       "description": "Number of parallel browser threads to use. Set to 1 to disable multithreading (useful for profiling)",

--- a/doc/audit-config.md
+++ b/doc/audit-config.md
@@ -39,6 +39,7 @@ The available configuration options are described below. See the
     `base_urls_visit_path`
   - if set to 1 then pages will just be visited without any crawling for
     additional links
+  - if set to 0 then all pages found within scope will be scanned
 - `thread_count`
   - the number of browsers, and threads CWAC will use
   - a number equal to the number of CPU cores is most efficient

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -525,7 +525,7 @@ class Crawler:
     while queue:
       parent_url, url = queue.pop()
 
-      if pages_scanned >= self.config.max_links_per_domain:
+      if self.config.max_links_per_domain and pages_scanned >= self.config.max_links_per_domain:
         logger.info('Max pages scanned reached %s', base_url)
         break
 

--- a/src/verify.py
+++ b/src/verify.py
@@ -16,6 +16,10 @@ def verify_axe_results(max_links_per_domain: int, pages_scanned: dict[str, set[s
   """
   # Check that each site had the correct number of pages scanned
   # outputs non-conforming sites to the log
+  # A max_links_per_domain of 0 means no limit, so there is no expected count
+  # to compare against and the check is skipped.
+  if max_links_per_domain == 0:
+    return
   for key, value in pages_scanned.items():
     correct_len = max_links_per_domain
     if len(value) != correct_len:

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,0 +1,39 @@
+"""Tests the behaviour of the verify_axe_results function."""
+
+import logging
+
+from src.verify import verify_axe_results
+
+
+def test_no_warning_when_max_links_per_domain_is_zero(caplog: logging.Logger) -> None:
+  """A max_links_per_domain of 0 means no limit, so counts are not checked."""
+  with caplog.at_level(logging.WARNING, logger='cwac'):
+    verify_axe_results(
+      max_links_per_domain=0,
+      pages_scanned={'https://example.govt.nz': {'https://example.govt.nz/a', 'https://example.govt.nz/b'}},
+    )
+
+  assert caplog.records == []
+
+
+def test_warning_when_page_count_does_not_match_limit(caplog: logging.Logger) -> None:
+  """A site with fewer pages than the limit is reported."""
+  with caplog.at_level(logging.WARNING, logger='cwac'):
+    verify_axe_results(
+      max_links_per_domain=3,
+      pages_scanned={'https://example.govt.nz': {'https://example.govt.nz/a'}},
+    )
+
+  assert len(caplog.records) == 1
+  assert 'had 1 pages scanned, not 3' in caplog.records[0].getMessage()
+
+
+def test_no_warning_when_page_count_matches_limit(caplog: logging.Logger) -> None:
+  """A site with exactly the expected number of pages is not reported."""
+  with caplog.at_level(logging.WARNING, logger='cwac'):
+    verify_axe_results(
+      max_links_per_domain=2,
+      pages_scanned={'https://example.govt.nz': {'https://example.govt.nz/a', 'https://example.govt.nz/b'}},
+    )
+
+  assert caplog.records == []


### PR DESCRIPTION
## What changed
- `max_links_per_domain: 0` now means "scan all pages found within scope" instead of being invalid (schema minimum was 1) or stopping after the first URL.
- The crawler skips the per-domain page cap when the value is 0.
- `verify.py` no longer logs a "had N pages scanned, not M" mismatch warning when there is no limit, and `doc/audit-config.md` documents the new behaviour.

## Why
Fixes https://github.com/GOVTNZ/cwac/issues/213 — previously the only way to scan a whole site was a large value like `1000000`, which made the verify step log a misleading "not 1000000" warning.

## How to verify
```sh
git fetch https://github.com/olitreadwell/cwac.git feat/max_links_per_domain-zero-means-all
git checkout FETCH_HEAD
pip install -r requirements.txt && pytest .
ruff check && ruff format --check --diff
pipx run check-jsonschema config.schema.json --check-metaschema
pipx run check-jsonschema config/config_default.json --schemafile config.schema.json
```