### PR TITLE
refactor: simplify `CSVWriter` into a single primary function for appending rows

### DIFF
--- a/src/audit_manager.py
+++ b/src/audit_manager.py
@@ -137,16 +137,17 @@ class AuditManager:
 
       # Write to anti-bot.csv
       csv_writer = CSVWriter()
-      csv_writer.add_rows(
+      csv_writer.append_rows(
+        f'./results/{self.config.audit_name}/anti_bot.csv',
         {
           'organisation': org['organisation'],
           'domain': netloc,
           'url': url,
           'anti_bot_check': status,
           'viewport_size': self.browser.viewport_size,
-        }
+        },
       )
-      csv_writer.write_csv_file(f'./results/{self.config.audit_name}/anti_bot.csv')
+
       self.discarded_urls[url] = status
 
     return status
@@ -357,8 +358,7 @@ class AuditManager:
 
         # Write results
         csv_writer = CSVWriter()
-        csv_writer.add_rows(*audit_result)
-        csv_writer.write_csv_file(f'./results/{self.config.audit_name}/{audit_name}.csv')
+        csv_writer.append_rows(f'./results/{self.config.audit_name}/{audit_name}.csv', *audit_result)
 
         # At least one audit successfully produced results
         any_audit_succeeded = True

--- a/src/audit_manager.py
+++ b/src/audit_manager.py
@@ -138,15 +138,13 @@ class AuditManager:
       # Write to anti-bot.csv
       csv_writer = CSVWriter()
       csv_writer.add_rows(
-        [
-          {
-            'organisation': org['organisation'],
-            'domain': netloc,
-            'url': url,
-            'anti_bot_check': status,
-            'viewport_size': self.browser.viewport_size,
-          }
-        ]
+        {
+          'organisation': org['organisation'],
+          'domain': netloc,
+          'url': url,
+          'anti_bot_check': status,
+          'viewport_size': self.browser.viewport_size,
+        }
       )
       csv_writer.write_csv_file(f'./results/{self.config.audit_name}/anti_bot.csv')
       self.discarded_urls[url] = status
@@ -287,7 +285,7 @@ class AuditManager:
         test_instance = audit['audit_class'](config=self.config, browser=self.browser, **audit['kwargs'])
 
         try:
-          audit_result = test_instance.run()
+          audit_result: list[dict[str, Any]] | bool = test_instance.run()
         except selenium.common.exceptions.WebDriverException:
           logger.exception(
             'Due to WebDriverException, test %s skipped on viewport %s for website %s',
@@ -359,7 +357,7 @@ class AuditManager:
 
         # Write results
         csv_writer = CSVWriter()
-        csv_writer.add_rows(audit_result)
+        csv_writer.add_rows(*audit_result)
         csv_writer.write_csv_file(f'./results/{self.config.audit_name}/{audit_name}.csv')
 
         # At least one audit successfully produced results

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -368,13 +368,15 @@ class Crawler:
       )
       # Write bad response codes with CSVWriter
       csv_writer = src.output.CSVWriter()
-      csv_writer.add_row(
-        {
-          'base_url': base_url,
-          'parent_url': parent_url,
-          'url': url_data['final_url'],
-          'status_code': url_data['status_code'],
-        }
+      csv_writer.add_rows(
+        [
+          {
+            'base_url': base_url,
+            'parent_url': parent_url,
+            'url': url_data['final_url'],
+            'status_code': url_data['status_code'],
+          }
+        ]
       )
       if self.config.record_unexpected_response_codes:
         csv_writer.write_csv_file(f'./results/{self.config.audit_name}/unexpected_response_codes.csv')

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -369,14 +369,12 @@ class Crawler:
       # Write bad response codes with CSVWriter
       csv_writer = src.output.CSVWriter()
       csv_writer.add_rows(
-        [
-          {
-            'base_url': base_url,
-            'parent_url': parent_url,
-            'url': url_data['final_url'],
-            'status_code': url_data['status_code'],
-          }
-        ]
+        {
+          'base_url': base_url,
+          'parent_url': parent_url,
+          'url': url_data['final_url'],
+          'status_code': url_data['status_code'],
+        }
       )
       if self.config.record_unexpected_response_codes:
         csv_writer.write_csv_file(f'./results/{self.config.audit_name}/unexpected_response_codes.csv')
@@ -575,14 +573,12 @@ class Crawler:
       # Write to audit_log.csv
       csv_writer = CSVWriter()
       csv_writer.add_rows(
-        [
-          {
-            'organisation': site_data['organisation'],
-            'base_url': site_data['url'],
-            'url': url,
-            'sector': site_data['sector'],
-          }
-        ]
+        {
+          'organisation': site_data['organisation'],
+          'base_url': site_data['url'],
+          'url': url,
+          'sector': site_data['sector'],
+        }
       )
       csv_writer.write_csv_file(f'./results/{self.config.audit_name}/audit_log.csv')
 
@@ -652,14 +648,12 @@ class Crawler:
     with self.config.lock:
       csv_writer = src.output.CSVWriter()
       csv_writer.add_rows(
-        [
-          {
-            'organisation': site_data['organisation'],
-            'base_url': site_data['url'],
-            'number_of_pages': pages_scanned,
-            'sector': site_data['sector'],
-          }
-        ]
+        {
+          'organisation': site_data['organisation'],
+          'base_url': site_data['url'],
+          'number_of_pages': pages_scanned,
+          'sector': site_data['sector'],
+        }
       )
       csv_writer.write_csv_file(f'./results/{self.config.audit_name}/pages_scanned.csv')
 

--- a/src/crawler.py
+++ b/src/crawler.py
@@ -366,18 +366,17 @@ class Crawler:
         url_data['final_url'],
         url_data['status_code'],
       )
-      # Write bad response codes with CSVWriter
-      csv_writer = src.output.CSVWriter()
-      csv_writer.add_rows(
-        {
-          'base_url': base_url,
-          'parent_url': parent_url,
-          'url': url_data['final_url'],
-          'status_code': url_data['status_code'],
-        }
-      )
       if self.config.record_unexpected_response_codes:
-        csv_writer.write_csv_file(f'./results/{self.config.audit_name}/unexpected_response_codes.csv')
+        csv_writer = src.output.CSVWriter()
+        csv_writer.append_rows(
+          f'./results/{self.config.audit_name}/unexpected_response_codes.csv',
+          {
+            'base_url': base_url,
+            'parent_url': parent_url,
+            'url': url_data['final_url'],
+            'status_code': url_data['status_code'],
+          },
+        )
 
       return False
     return src.filters.url_filter_by_header_content_type(url_data['final_url'], url_data['headers'])
@@ -572,15 +571,15 @@ class Crawler:
 
       # Write to audit_log.csv
       csv_writer = CSVWriter()
-      csv_writer.add_rows(
+      csv_writer.append_rows(
+        f'./results/{self.config.audit_name}/audit_log.csv',
         {
           'organisation': site_data['organisation'],
           'base_url': site_data['url'],
           'url': url,
           'sector': site_data['sector'],
-        }
+        },
       )
-      csv_writer.write_csv_file(f'./results/{self.config.audit_name}/audit_log.csv')
 
       self.register_audit_plugins(audit_manager, url, site_data)
       test_success = audit_manager.run_audits()
@@ -647,15 +646,15 @@ class Crawler:
     """Record the number of pages that were scanned for the site."""
     with self.config.lock:
       csv_writer = src.output.CSVWriter()
-      csv_writer.add_rows(
+      csv_writer.append_rows(
+        f'./results/{self.config.audit_name}/pages_scanned.csv',
         {
           'organisation': site_data['organisation'],
           'base_url': site_data['url'],
           'number_of_pages': pages_scanned,
           'sector': site_data['sector'],
-        }
+        },
       )
-      csv_writer.write_csv_file(f'./results/{self.config.audit_name}/pages_scanned.csv')
 
 
 class RandomQueue[T]:

--- a/src/output.py
+++ b/src/output.py
@@ -53,12 +53,11 @@ class CSVWriter:
     for row in rows:
       self.rows.append(row)
 
-  def write_csv_file(self, path: str, overwrite: bool = False) -> None:
+  def write_csv_file(self, path: str) -> None:
     """Write data to a CSV file.
 
     Args:
         path (str): path to write data
-        overwrite (bool): overwrite existing file
     """
     if not self.rows:
       return
@@ -66,11 +65,10 @@ class CSVWriter:
     keys = self.rows[0].keys()
 
     with self._get_file_lock(path):
-      file_exists = False if overwrite else os.path.exists(path)
-      file_mode = 'w' if overwrite else 'a'
-      with open(path, file_mode, encoding='utf-8-sig') as csvfile:
+      file_already_exists = os.path.exists(path)
+      with open(path, 'a', encoding='utf-8-sig') as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=keys)
-        if not file_exists:
+        if not file_already_exists:
           writer.writeheader()
         writer.writerows(self.rows)
 

--- a/src/output.py
+++ b/src/output.py
@@ -26,10 +26,6 @@ class CSVWriter:
   # A lock to prevent multiple threads writing to file_locks dict
   lock_for_file_locks = threading.Lock()
 
-  def __init__(self) -> None:
-    """Init variables."""
-    self.rows: list[dict[Any, Any]] = []
-
   def _get_file_lock(self, path: str) -> threading.Lock:
     """Get a lock for a file.
 
@@ -44,25 +40,17 @@ class CSVWriter:
         CSVWriter.file_locks[path] = threading.Lock()
       return CSVWriter.file_locks[path]
 
-  def add_rows(self, *rows: dict[Any, Any]) -> None:
-    """Add a list of rows to the CSV row buffer.
+  def append_rows(self, path: str, *rows: dict[Any, Any]) -> None:
+    """Add a list of rows to a CSV file.
 
     Args:
+        path (str): path to file
         rows (list[dict[Any, Any]]): list of rows of data
     """
-    for row in rows:
-      self.rows.append(row)
-
-  def write_csv_file(self, path: str) -> None:
-    """Write data to a CSV file.
-
-    Args:
-        path (str): path to write data
-    """
-    if not self.rows:
+    if not rows:
       return
 
-    keys = self.rows[0].keys()
+    keys = rows[0].keys()
 
     with self._get_file_lock(path):
       file_already_exists = os.path.exists(path)
@@ -70,9 +58,7 @@ class CSVWriter:
         writer = csv.DictWriter(csvfile, fieldnames=keys)
         if not file_already_exists:
           writer.writeheader()
-        writer.writerows(self.rows)
-
-    self.rows = []
+        writer.writerows(rows)
 
 
 def output_init_message(config: Config) -> None:
@@ -183,20 +169,18 @@ def print_progress_bar(
 
   # Write progress data to CSV file
   csv_writer = CSVWriter()
-
-  output_row = {
-    'time': time.time(),
-    'iteration': iteration,
-    'total': total,
-    'speed': f'{speed:.2f}',
-    'percent': percent,
-    'elapsed': f'{elapsed}',
-    'remaining': f'{time_est}',
-  }
-
-  csv_writer.add_rows(output_row)
-
-  csv_writer.write_csv_file(f'./results/{config.audit_name}/progress.csv')
+  csv_writer.append_rows(
+    f'./results/{config.audit_name}/progress.csv',
+    {
+      'time': time.time(),
+      'iteration': iteration,
+      'total': total,
+      'speed': f'{speed:.2f}',
+      'percent': percent,
+      'elapsed': f'{elapsed}',
+      'remaining': f'{time_est}',
+    },
+  )
 
   # Print New Line on Complete
   if iteration == total:

--- a/src/output.py
+++ b/src/output.py
@@ -53,18 +53,15 @@ class CSVWriter:
     for row in rows:
       self.rows.append(row)
 
-  def write_csv_file(self, path: str, overwrite: bool = False) -> bool:
+  def write_csv_file(self, path: str, overwrite: bool = False) -> None:
     """Write data to a CSV file.
 
     Args:
         path (str): path to write data
         overwrite (bool): overwrite existing file
-
-    Returns:
-        bool: True if write successful, else False
     """
     if not self.rows:
-      return False
+      return
 
     keys = self.rows[0].keys()
 
@@ -78,8 +75,6 @@ class CSVWriter:
         writer.writerows(self.rows)
 
     self.rows = []
-
-    return True
 
 
 def output_init_message(config: Config) -> None:

--- a/src/output.py
+++ b/src/output.py
@@ -44,14 +44,6 @@ class CSVWriter:
         CSVWriter.file_locks[path] = threading.Lock()
       return CSVWriter.file_locks[path]
 
-  def add_row(self, row: dict[Any, Any]) -> None:
-    """Add a row to the CSV row buffer.
-
-    Args:
-        row (dict[Any, Any]): A dictionary of row contents
-    """
-    self.rows.append(row)
-
   def add_rows(self, rows: list[dict[Any, Any]]) -> None:
     """Add a list of rows to the CSV row buffer.
 
@@ -209,7 +201,7 @@ def print_progress_bar(
     'remaining': f'{time_est}',
   }
 
-  csv_writer.add_row(output_row)
+  csv_writer.add_rows([output_row])
 
   csv_writer.write_csv_file(f'./results/{config.audit_name}/progress.csv')
 

--- a/src/output.py
+++ b/src/output.py
@@ -39,11 +39,11 @@ class CSVWriter:
       return CSVWriter.file_locks[path]
 
   def append_rows(self, path: str, *rows: dict[Any, Any]) -> None:
-    """Add a list of rows to a CSV file.
+    """Append one or more rows to a CSV file.
 
     Args:
         path (str): path to file
-        rows (list[dict[Any, Any]]): list of rows of data
+        *rows (dict[str, Any]): one or more rows of data
     """
     if not rows:
       return

--- a/src/output.py
+++ b/src/output.py
@@ -11,8 +11,6 @@ import pandas as pd
 
 from config import Config
 
-# pylint: disable=too-many-locals
-
 logger = logging.getLogger('cwac')
 
 

--- a/src/output.py
+++ b/src/output.py
@@ -44,20 +44,6 @@ class CSVWriter:
         CSVWriter.file_locks[path] = threading.Lock()
       return CSVWriter.file_locks[path]
 
-  def read_csv(self, path: str) -> list[dict[Any, Any]]:
-    """Read a CSV file as a list of dictionaries.
-
-    Args:
-        path (str): path to CSV file
-
-    Returns:
-        list[dict[Any, Any]]: list of dictionaries
-    """
-    with self.get_file_lock(path), open(path, encoding='utf-8-sig') as csvfile:
-      reader = csv.DictReader(csvfile)
-      rows = list(reader)
-    return rows
-
   def add_row(self, row: dict[Any, Any]) -> None:
     """Add a row to the CSV row buffer.
 

--- a/src/output.py
+++ b/src/output.py
@@ -44,7 +44,7 @@ class CSVWriter:
         CSVWriter.file_locks[path] = threading.Lock()
       return CSVWriter.file_locks[path]
 
-  def add_rows(self, rows: list[dict[Any, Any]]) -> None:
+  def add_rows(self, *rows: dict[Any, Any]) -> None:
     """Add a list of rows to the CSV row buffer.
 
     Args:
@@ -194,7 +194,7 @@ def print_progress_bar(
     'remaining': f'{time_est}',
   }
 
-  csv_writer.add_rows([output_row])
+  csv_writer.add_rows(output_row)
 
   csv_writer.write_csv_file(f'./results/{config.audit_name}/progress.csv')
 

--- a/src/output.py
+++ b/src/output.py
@@ -30,7 +30,7 @@ class CSVWriter:
     """Init variables."""
     self.rows: list[dict[Any, Any]] = []
 
-  def get_file_lock(self, path: str) -> threading.Lock:
+  def _get_file_lock(self, path: str) -> threading.Lock:
     """Get a lock for a file.
 
     Args:
@@ -76,7 +76,7 @@ class CSVWriter:
 
     keys = self.rows[0].keys()
 
-    with self.get_file_lock(path):
+    with self._get_file_lock(path):
       file_exists = False if overwrite else os.path.exists(path)
       file_mode = 'w' if overwrite else 'a'
       with open(path, file_mode, encoding='utf-8-sig') as csvfile:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -25,11 +25,9 @@ class TestCSVWriter:
     writer = CSVWriter()
 
     writer.add_rows(
-      [
-        {'name': 'Bob', 'age': 20, 'location': 'Wellington'},
-        {'name': 'Alice', 'age': 31, 'location': 'Wellington'},
-        {'name': 'Greg', 'age': 23, 'location': 'Auckland'},
-      ]
+      {'name': 'Bob', 'age': 20, 'location': 'Wellington'},
+      {'name': 'Alice', 'age': 31, 'location': 'Wellington'},
+      {'name': 'Greg', 'age': 23, 'location': 'Auckland'},
     )
 
     writer.write_csv_file('file.csv')
@@ -50,11 +48,9 @@ class TestCSVWriter:
     writer = CSVWriter()
 
     writer.add_rows(
-      [
-        {'name': 'Bob', 'age': 20, 'location': 'Wellington'},
-        {'name': 'Alice', 'age': 31, 'location': 'Wellington'},
-        {'name': 'Greg', 'age': 23, 'location': 'Auckland'},
-      ]
+      {'name': 'Bob', 'age': 20, 'location': 'Wellington'},
+      {'name': 'Alice', 'age': 31, 'location': 'Wellington'},
+      {'name': 'Greg', 'age': 23, 'location': 'Auckland'},
     )
 
     writer.write_csv_file('file.csv')
@@ -76,9 +72,7 @@ class TestCSVWriter:
     writer = CSVWriter()
 
     writer.add_rows(
-      [
-        {'name': 'Bob', 'age': 20, 'location': 'Wellington'},
-      ]
+      {'name': 'Bob', 'age': 20, 'location': 'Wellington'},
     )
 
     writer.write_csv_file('file.csv')
@@ -86,10 +80,8 @@ class TestCSVWriter:
     assert os.path.exists('file.csv') is True
 
     writer.add_rows(
-      [
-        {'name': 'Alice', 'age': 31, 'location': 'Wellington'},
-        {'name': 'Greg', 'age': 23, 'location': 'Auckland'},
-      ]
+      {'name': 'Alice', 'age': 31, 'location': 'Wellington'},
+      {'name': 'Greg', 'age': 23, 'location': 'Auckland'},
     )
 
     writer.write_csv_file('file.csv')
@@ -109,11 +101,9 @@ class TestCSVWriter:
     writer = CSVWriter()
 
     writer.add_rows(
-      [
-        {'name': 'Bob', 'age': 20, 'location': 'Wellington'},
-        {'age': 31, 'name': 'Alice', 'location': 'Wellington'},
-        {'location': 'Auckland', 'age': 23, 'name': 'Greg'},
-      ]
+      {'name': 'Bob', 'age': 20, 'location': 'Wellington'},
+      {'age': 31, 'name': 'Alice', 'location': 'Wellington'},
+      {'location': 'Auckland', 'age': 23, 'name': 'Greg'},
     )
 
     writer.write_csv_file('file.csv')

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -71,6 +71,39 @@ class TestCSVWriter:
     with open('file.csv', encoding='utf-8') as f:
       assert f.read() == textwrap.dedent(expected).lstrip()
 
+  def test_multiple_writes_to_same_file(self) -> None:
+    """Writes new rows to a csv file, without duplicating the header."""
+    writer = CSVWriter()
+
+    writer.add_rows(
+      [
+        {'name': 'Bob', 'age': 20, 'location': 'Wellington'},
+      ]
+    )
+
+    writer.write_csv_file('file.csv')
+
+    assert os.path.exists('file.csv') is True
+
+    writer.add_rows(
+      [
+        {'name': 'Alice', 'age': 31, 'location': 'Wellington'},
+        {'name': 'Greg', 'age': 23, 'location': 'Auckland'},
+      ]
+    )
+
+    writer.write_csv_file('file.csv')
+
+    expected = """
+      name,age,location
+      Bob,20,Wellington
+      Alice,31,Wellington
+      Greg,23,Auckland
+    """
+
+    with open('file.csv', encoding='utf-8-sig') as f:
+      assert f.read() == textwrap.dedent(expected).lstrip()
+
   def test_column_ordering_is_consistent(self) -> None:
     """Orders columns based on the first row."""
     writer = CSVWriter()

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -16,7 +16,7 @@ class TestCSVWriter:
     """Skips writing a file when no rows have been added."""
     writer = CSVWriter()
 
-    writer.write_csv_file('file.csv')
+    writer.append_rows('file.csv')
 
     assert os.path.exists('file.csv') is not True
 
@@ -24,13 +24,13 @@ class TestCSVWriter:
     """Writes each row to a csv file, with a header."""
     writer = CSVWriter()
 
-    writer.add_rows(
+    writer.append_rows(
+      'file.csv',
       {'name': 'Bob', 'age': 20, 'location': 'Wellington'},
       {'name': 'Alice', 'age': 31, 'location': 'Wellington'},
       {'name': 'Greg', 'age': 23, 'location': 'Auckland'},
     )
 
-    writer.write_csv_file('file.csv')
     assert os.path.exists('file.csv') is True
 
     expected = """
@@ -47,13 +47,12 @@ class TestCSVWriter:
     """Writes a bom before the header row."""
     writer = CSVWriter()
 
-    writer.add_rows(
+    writer.append_rows(
+      'file.csv',
       {'name': 'Bob', 'age': 20, 'location': 'Wellington'},
       {'name': 'Alice', 'age': 31, 'location': 'Wellington'},
       {'name': 'Greg', 'age': 23, 'location': 'Auckland'},
     )
-
-    writer.write_csv_file('file.csv')
 
     assert os.path.exists('file.csv') is True
 
@@ -67,24 +66,22 @@ class TestCSVWriter:
     with open('file.csv', encoding='utf-8') as f:
       assert f.read() == textwrap.dedent(expected).lstrip()
 
-  def test_multiple_writes_to_same_file(self) -> None:
+  def test_appends_to_existing_file(self) -> None:
     """Writes new rows to a csv file, without duplicating the header."""
     writer = CSVWriter()
 
-    writer.add_rows(
+    writer.append_rows(
+      'file.csv',
       {'name': 'Bob', 'age': 20, 'location': 'Wellington'},
     )
 
-    writer.write_csv_file('file.csv')
-
     assert os.path.exists('file.csv') is True
 
-    writer.add_rows(
+    writer.append_rows(
+      'file.csv',
       {'name': 'Alice', 'age': 31, 'location': 'Wellington'},
       {'name': 'Greg', 'age': 23, 'location': 'Auckland'},
     )
-
-    writer.write_csv_file('file.csv')
 
     expected = """
       name,age,location
@@ -100,13 +97,12 @@ class TestCSVWriter:
     """Orders columns based on the first row."""
     writer = CSVWriter()
 
-    writer.add_rows(
+    writer.append_rows(
+      'file.csv',
       {'name': 'Bob', 'age': 20, 'location': 'Wellington'},
       {'age': 31, 'name': 'Alice', 'location': 'Wellington'},
       {'location': 'Auckland', 'age': 23, 'name': 'Greg'},
     )
-
-    writer.write_csv_file('file.csv')
 
     assert os.path.exists('file.csv') is True
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -16,7 +16,7 @@ class TestCSVWriter:
     """Skips writing a file when no rows have been added."""
     writer = CSVWriter()
 
-    assert not writer.write_csv_file('file.csv')
+    writer.write_csv_file('file.csv')
 
     assert os.path.exists('file.csv') is not True
 
@@ -32,7 +32,7 @@ class TestCSVWriter:
       ]
     )
 
-    assert writer.write_csv_file('file.csv')
+    writer.write_csv_file('file.csv')
     assert os.path.exists('file.csv') is True
 
     expected = """
@@ -57,7 +57,8 @@ class TestCSVWriter:
       ]
     )
 
-    assert writer.write_csv_file('file.csv')
+    writer.write_csv_file('file.csv')
+
     assert os.path.exists('file.csv') is True
 
     expected = """
@@ -82,7 +83,8 @@ class TestCSVWriter:
       ]
     )
 
-    assert writer.write_csv_file('file.csv')
+    writer.write_csv_file('file.csv')
+
     assert os.path.exists('file.csv') is True
 
     expected = """

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -93,6 +93,44 @@ class TestCSVWriter:
     with open('file.csv', encoding='utf-8-sig') as f:
       assert f.read() == textwrap.dedent(expected).lstrip()
 
+  def test_ignores_missing_columns(self) -> None:
+    """Ignores columns missing in subsequent rows."""
+    writer = CSVWriter()
+
+    writer.append_rows(
+      'file.csv',
+      {'name': 'Bob', 'age': 20, 'location': 'Wellington'},
+      {'name': 'Alice', 'age': 31},
+      {'age': 23, 'location': 'Auckland'},
+    )
+
+    assert os.path.exists('file.csv') is True
+
+    expected = """
+      name,age,location
+      Bob,20,Wellington
+      Alice,31,
+      ,23,Auckland
+    """
+
+    with open('file.csv', encoding='utf-8-sig') as f:
+      assert f.read() == textwrap.dedent(expected).lstrip()
+
+  def test_raises_extra_columns(self) -> None:
+    """Errors when rows have extra columns."""
+    writer = CSVWriter()
+
+    with pytest.raises(ValueError):
+      writer.append_rows(
+        'file.csv',
+        {'name': 'Bob', 'age': 20},
+        {'name': 'Alice', 'age': 31, 'location': 'Wellington'},
+        {'name': 'Greg', 'age': 23, 'location': 'Auckland'},
+      )
+
+    # the file will still end up being created due to the open mode
+    assert os.path.exists('file.csv')
+
   def test_column_ordering_is_consistent(self) -> None:
     """Orders columns based on the first row."""
     writer = CSVWriter()

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,96 @@
+"""Tests the behaviour of the output classes and functions."""
+
+import os
+import textwrap
+
+import pytest
+
+from src.output import CSVWriter
+
+
+@pytest.mark.usefixtures('fs')
+class TestCSVWriter:
+  """Tests writing csv files using the CSVWriter class."""
+
+  def test_csv_is_not_written_when_no_rows(self) -> None:
+    """Skips writing a file when no rows have been added."""
+    writer = CSVWriter()
+
+    assert not writer.write_csv_file('file.csv')
+
+    assert os.path.exists('file.csv') is not True
+
+  def test_csv_is_written(self) -> None:
+    """Writes each row to a csv file, with a header."""
+    writer = CSVWriter()
+
+    writer.add_rows(
+      [
+        {'name': 'Bob', 'age': 20, 'location': 'Wellington'},
+        {'name': 'Alice', 'age': 31, 'location': 'Wellington'},
+        {'name': 'Greg', 'age': 23, 'location': 'Auckland'},
+      ]
+    )
+
+    assert writer.write_csv_file('file.csv')
+    assert os.path.exists('file.csv') is True
+
+    expected = """
+      name,age,location
+      Bob,20,Wellington
+      Alice,31,Wellington
+      Greg,23,Auckland
+    """
+
+    with open('file.csv', encoding='utf-8-sig') as f:
+      assert f.read() == textwrap.dedent(expected).lstrip()
+
+  def test_csv_is_written_with_bom(self) -> None:
+    """Writes a bom before the header row."""
+    writer = CSVWriter()
+
+    writer.add_rows(
+      [
+        {'name': 'Bob', 'age': 20, 'location': 'Wellington'},
+        {'name': 'Alice', 'age': 31, 'location': 'Wellington'},
+        {'name': 'Greg', 'age': 23, 'location': 'Auckland'},
+      ]
+    )
+
+    assert writer.write_csv_file('file.csv')
+    assert os.path.exists('file.csv') is True
+
+    expected = """
+      \ufeffname,age,location
+      Bob,20,Wellington
+      Alice,31,Wellington
+      Greg,23,Auckland
+    """
+
+    with open('file.csv', encoding='utf-8') as f:
+      assert f.read() == textwrap.dedent(expected).lstrip()
+
+  def test_column_ordering_is_consistent(self) -> None:
+    """Orders columns based on the first row."""
+    writer = CSVWriter()
+
+    writer.add_rows(
+      [
+        {'name': 'Bob', 'age': 20, 'location': 'Wellington'},
+        {'age': 31, 'name': 'Alice', 'location': 'Wellington'},
+        {'location': 'Auckland', 'age': 23, 'name': 'Greg'},
+      ]
+    )
+
+    assert writer.write_csv_file('file.csv')
+    assert os.path.exists('file.csv') is True
+
+    expected = """
+      name,age,location
+      Bob,20,Wellington
+      Alice,31,Wellington
+      Greg,23,Auckland
+    """
+
+    with open('file.csv', encoding='utf-8-sig') as f:
+      assert f.read() == textwrap.dedent(expected).lstrip()


### PR DESCRIPTION
When reviewing this class as part of #348, I realized there were some unused and duplicated code, but then later realized ultimately what we're using this for is locking the file to do thread safe writes, and appending rows to a csv file.

In light of that, I've ended up refactoring the class to a single public `append_rows` function, along with adding tests