### PR TITLE
chore: don't have flake8 or pylint enforce line length

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,6 +4,7 @@ extend-ignore=
   E203
   E114
   E111
+  E501
 max-line-length = 120
 exclude =
     __pycache__

--- a/.pylintrc
+++ b/.pylintrc
@@ -21,5 +21,5 @@ ignore-docstrings=yes
 ignore-patterns=.venv
 
 [MESSAGES CONTROL]
-disable=broad-exception-caught, bad-indentation
+disable=broad-exception-caught, bad-indentation, line-too-long
 fail-on=useless-suppression, use-symbolic-message-instead

--- a/config.py
+++ b/config.py
@@ -288,7 +288,7 @@ class Config:
         self.chrome_binary_location = f'./chrome/linux-{chrome_version}/chrome-linux64/chrome'
       elif info.system == 'Darwin' and info.machine == 'arm64':
         # pylint: disable-next=line-too-long
-        self.chrome_binary_location = f'./chrome/mac_arm-{chrome_version}/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing'  # noqa: E501 RUF100
+        self.chrome_binary_location = f'./chrome/mac_arm-{chrome_version}/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing'
       else:
         raise ValueError(
           f'chrome_binary_location cannot be automatically determined for {info.system} {info.machine} '


### PR DESCRIPTION
I'm still keen to keep the old linters around for a bit longer to see what we might not be catching with `ruff`, but now that we're enforcing [`unused-noqa`](https://docs.astral.sh/ruff/rules/unused-noqa/) it's a bit awkward to inline disable `flake8` line length violations