### PR TITLE
fix: cancel all animations on page before running axe-core JS

### DIFF
--- a/src/audit_plugins/axe_core_audit.py
+++ b/src/audit_plugins/axe_core_audit.py
@@ -62,6 +62,7 @@ class AxeCoreAudit(DefaultAudit):
         # that we cannot recover from, so exit the program.
         sys.exit(1)
       run_axe = (
+        'document.getAnimations().forEach(animation => animation.cancel());'
         'var callback = arguments[arguments.length - 1];'
         'axe.run({xpath: true, '
         "resultTypes:['violations']"


### PR DESCRIPTION
We noticed an  issue with intermittent axe-core `color-contrast` false positive results on sites which animated in content at page load e.g. CSS like:

```css
.hero {
  opacity: 0;
  transition: opacity .6s ease-out, transform .6s ease-out;
}
.hero.visible { opacity: 1 }
```

This change uses JS to forcibly cancel all active animations in the DOM just before the axe-core JS is run. 

After a number of manual tests, this appears to fix the issue although it is hard to be 100% certain because the issue was intermittent. 

