### PR TITLE
docs: fix typos and stale chromedriver path in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ which includes
 Level AA conformance. CWAC enables the partial fulfillment of
 [Article 9 of the United Nations Convention on the Rights of Persons with Disabilities (CRPD)](https://www.un.org/development/desa/disabilities/convention-on-the-rights-of-persons-with-disabilities/article-9-accessibility.html).
 
-Provided a list of URLS to visit, CWAC will check each page for
+Provided a list of URLs to visit, CWAC will check each page for
 automatically-identifiable accessibility issues and store the results in an
 easy-to-read CSV file.
 
 CWAC can also crawl each page as it goes to determine additional pages to check
 (up to a set max number per URL), respecting `robots.txt` and server signals
-when doing so. This makes it easy to check entire sites without knowing the all
+when doing so. This makes it easy to check entire sites without knowing all the
 paths beforehand.
 
 CWAC is designed to be extensible, so new forms of web testing can be added over
@@ -215,7 +215,7 @@ The steps to upgrade are:
 
 1. Run the command above (or manually visit site) to get latest stable _Chrome
    for Testing_.
-2. Update `pacakge.json` with the new version.
+2. Update `package.json` with the new version.
 3. Run `npm install` to download _Chrome for Testing_ and _Chromedriver_
    binaries corresponding to the new version from `package.json`. The binaries
    are downloaded to `chrome/` and `chromedriver/` respectively.
@@ -236,14 +236,14 @@ Crown copyright (c) 2024, Department of Internal Affairs on behalf of the New
 Zealand Government.
 
 This copyright, along with CWAC's GPL-3.0 license, does not extend to the
-third-party chromedriver binaries located in the `/drivers/` folder. Permission
-to re-use third party copyright material cannot be given by the Department of
-Internal Affairs.
+third-party chromedriver binaries located in the `chromedriver/` folder.
+Permission to re-use third party copyright material cannot be given by the
+Department of Internal Affairs.
 
 ### chromedriver binaries copyright and license
 
-CWAC includes chromedriver binaries at `/drivers/`. chromedriver licenses can be
-found in the `/drivers/` folder.
+CWAC includes chromedriver binaries at `chromedriver/`. chromedriver licenses
+can be found in the `chromedriver/` folder.
 
 ```plain
 // Copyright 2015 The Chromium Authors

--- a/doc/audit-config.md
+++ b/doc/audit-config.md
@@ -144,7 +144,7 @@ The available configuration options are described below. See the
 > Ignore advanced configurations for now. There are advanced configurations of
 > CWAC that use other CSV files - see the settings for `base_urls_nohead_path`
 > above. You can ignore these when getting started - the only CSV file actually
-> required is the "visits" CSV (described below) As well as the JSON
+> required is the "visits" CSV (described below). As well as the JSON
 > configuration, CWAC needs a CSV file with a set of base URLs that will be
 > visited, crawled and scanned.
 

--- a/doc/audit-results.md
+++ b/doc/audit-results.md
@@ -45,8 +45,8 @@ findings discovered by the scan.
 
 > [!WARNING]
 >
-> All CSV files start with Byte-order Mark (BOM) All generated CSV files start
-> with 3 hidden bytes called a
+> All CSV files start with a Byte-order Mark (BOM). All generated CSV files
+> start with 3 hidden bytes called a
 > [BOM marker](https://en.wikipedia.org/wiki/Byte_order_mark). The BOM allows MS
 > Excel to choose the correct character set for the data and thereby avoid
 > broken looking characters.

--- a/doc/audits/reflow-audit.md
+++ b/doc/audits/reflow-audit.md
@@ -90,7 +90,7 @@ reflow-specific result fields:
   - `0` means no horizontal overflow was detected.
   - `1` means horizontal overflow was detected for this row.
 - `overflows` (boolean true/false)
-  - Indicates whether there an overflow issue with this URL
+  - Indicates whether there is an overflow issue with this URL
   - Issue exists if value is `TRUE`
 - `overflow_amount_px`
   - How wide the hidden part of the page is at a 320px viewport size.


### PR DESCRIPTION
Small docs cleanup across the README and the audit guides.

- "URLS" -> "URLs" in the README
- "the all paths" -> "all the paths" in the README
- "pacakge.json" -> "package.json" in the README
- stale `/drivers/` references -> `chromedriver/` in the README copyright section
- missing period in the audit-config.md note about the visits CSV
- missing article and period in the audit-results.md BOM note
- "there an" -> "there is an" in reflow-audit.md

The chromedriver binaries are downloaded to `chromedriver/` via `npm install`, so the README sections still pointing at `/drivers/` were out of date.

Drafted with AI assistance. I found each issue, checked it against the current docs, and reviewed the diff line by line.
